### PR TITLE
Tweak commands copied to clipboard to work with both cmd.exe and powershell on Windows

### DIFF
--- a/src/Verify/Clipboard/ClipboardCapture.cs
+++ b/src/Verify/Clipboard/ClipboardCapture.cs
@@ -17,8 +17,8 @@ static class ClipboardCapture
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            moveCommand = "move /Y \"{0}\" \"{1}\"";
-            deleteCommand = "del \"{0}\"";
+            moveCommand = "cmd /c move /Y \"{0}\" \"{1}\"";
+            deleteCommand = "cmd /c del \"{0}\"";
             return;
         }
 


### PR DESCRIPTION
Currently the move and del comand copied to the clipboard are specific to cmd.exe  and do no work if pasted into a powershell console.  This change addresses this by pre-pending  `cmd /c ` to the front of the commands.  The result is that the commands work in both cmd and powershell

