### PR TITLE
[WIP] Throw early when VerifyBase-derived classes fail to call the base constructor explicitly

### DIFF
--- a/src/Verify.Xunit/VerifyBase.cs
+++ b/src/Verify.Xunit/VerifyBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using VerifyTests;
 
 namespace VerifyXunit
@@ -11,6 +12,9 @@ namespace VerifyXunit
 
         public VerifyBase(VerifySettings? settings = null, [CallerFilePath] string sourceFile = "")
         {
+            if ((settings == null) && (sourceFile == ""))
+                throw new InvalidOperationException($"{nameof(VerifyBase)}.ctor must be called explicitly.");
+
             this.settings = settings;
             this.sourceFile = sourceFile;
         }


### PR DESCRIPTION
Just ran into this caveat: In a VerifyBase-derived class, it's a difference whether the base constructor is being called explicitly or not. That is, the following constructors will compile differently

````
class MyTests : VerifyBase
{
    public MyTests() : base() {}
````
vs
````
    public MyTests() {}
}
````

The first one will assign a sensible value to `sourceFile` whereas the second one will just assign the default values. Upon calling any Verify-method, we now get an ArgumentNullException and it's not immediately obvious why that is.

I assume that virtually no method in VerifyBase is properly usable without a valid value for sourceFile, so the change in the PR is a proposal to fail early. Can be worked into the resp. VerifyBase classes of any other test framework if found to be useful.