### PR TITLE
Use ExtensionOrTxt in InnerVerifier so a possible extension override in the settings won't go unnoticed.

### DIFF
--- a/src/Verify/Verifier/InnerVerifier_Inner.cs
+++ b/src/Verify/Verifier/InnerVerifier_Inner.cs
@@ -82,7 +82,7 @@ namespace VerifyTests
                 return true;
             }
 
-            extension = "txt";
+            extension = settings.ExtensionOrTxt();
 
             if (VerifierSettings.StrictJson)
             {


### PR DESCRIPTION
Fixes #307.