### PR TITLE
Scrub numeric ids

### DIFF
--- a/docs/mdsource/serializer-settings.source.md
+++ b/docs/mdsource/serializer-settings.source.md
@@ -94,6 +94,25 @@ To disable this behavior globally use:
 snippet: DontScrubDateTimes
 
 
+## Numeric Ids are scrubbed
+
+By default numeric properties (`int`, `uint`, `long`, and `ulong`) suffixed with `Id` are sanitized during verification. This is done by finding each id and taking a counter based that that specific id. That counter is then used replace the id values. This allows for repeatable tests when id are bing generated.
+
+snippet: NumericId
+
+Results in the following:
+
+snippet: SerializationTests.NumericIdScrubbing.verified.txt
+
+To disable this globally use:
+
+snippet: DisableNumericIdGlobal
+
+To disable this behavior globally use:
+
+snippet: DisableNumericIdGlobal
+
+
 ## Default Booleans are ignored
 
 By default values of `bool` and `bool?` are ignored during verification. So properties that equate to 'false' will not be written,

--- a/docs/named-tuples.md
+++ b/docs/named-tuples.md
@@ -21,7 +21,7 @@ static (bool Member1, string Member2, string Member3) MethodWithNamedTuple()
     return (true, "A", "B");
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L556-L563' title='Snippet source file'>snippet source</a> | <a href='#snippet-methodwithnamedtuple' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L603-L610' title='Snippet source file'>snippet source</a> | <a href='#snippet-methodwithnamedtuple' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Can be verified:
@@ -31,7 +31,7 @@ Can be verified:
 ```cs
 await Verifier.Verify(() => MethodWithNamedTuple());
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L549-L553' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifytuple' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L596-L600' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifytuple' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Resulting in:

--- a/docs/scrubbers.md
+++ b/docs/scrubbers.md
@@ -56,7 +56,7 @@ For example remove lines containing `text`:
 ```cs
 verifySettings.ScrubLines(line => line.Contains("text"));
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L439-L443' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrublines' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L486-L490' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrublines' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -71,7 +71,7 @@ For example remove lines containing `text1` or `text2`
 ```cs
 verifySettings.ScrubLinesContaining("text1", "text2");
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L445-L449' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrublinescontaining' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L492-L496' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrublinescontaining' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Case insensitive by default (StringComparison.OrdinalIgnoreCase).
@@ -83,7 +83,7 @@ Case insensitive by default (StringComparison.OrdinalIgnoreCase).
 ```cs
 verifySettings.ScrubLinesContaining(StringComparison.Ordinal, "text1", "text2");
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L451-L455' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrublinescontainingordinal' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L498-L502' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrublinescontainingordinal' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -98,7 +98,7 @@ For example converts lines to upper case:
 ```cs
 verifySettings.ScrubLinesWithReplace(line => line.ToUpper());
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L457-L461' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrublineswithreplace' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L504-L508' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrublineswithreplace' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -111,7 +111,7 @@ Replaces `Environment.MachineName` with `TheMachineName`.
 ```cs
 verifySettings.ScrubMachineName();
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L463-L467' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrubmachinename' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L510-L514' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrubmachinename' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/serializer-settings.md
+++ b/docs/serializer-settings.md
@@ -84,7 +84,7 @@ JsonSerializerSettings settings = new()
     DefaultValueHandling = DefaultValueHandling.Ignore
 };
 ```
-<sup><a href='/src/Verify/Serialization/SerializationSettings.cs#L119-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-defaultserialization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify/Serialization/SerializationSettings.cs#L127-L136' title='Snippet source file'>snippet source</a> | <a href='#snippet-defaultserialization' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -104,7 +104,7 @@ To disable this behavior globally use:
 ```cs
 VerifierSettings.ModifySerialization(_ => _.DontIgnoreEmptyCollections());
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L368-L372' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontignoreemptycollections' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L415-L419' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontignoreemptycollections' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -126,7 +126,7 @@ GuidTarget target = new()
 
 await Verifier.Verify(target);
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L622-L635' title='Snippet source file'>snippet source</a> | <a href='#snippet-guid' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L669-L682' title='Snippet source file'>snippet source</a> | <a href='#snippet-guid' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in the following:
@@ -151,7 +151,7 @@ To disable this behavior globally use:
 ```cs
 VerifierSettings.ModifySerialization(_ => _.DontScrubGuids());
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L377-L381' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontscrubguids' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L424-L428' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontscrubguids' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Strings containing inline Guids can also be scrubbed. To enable this behavior, use:
@@ -161,7 +161,7 @@ Strings containing inline Guids can also be scrubbed. To enable this behavior, u
 ```cs
 VerifierSettings.ScrubInlineGuids();
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L404-L408' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrubinlineguids' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L451-L455' title='Snippet source file'>snippet source</a> | <a href='#snippet-scrubinlineguids' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -213,7 +213,119 @@ To disable this behavior globally use:
 ```cs
 VerifierSettings.ModifySerialization(_ => _.DontScrubDateTimes());
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L413-L417' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontscrubdatetimes' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L460-L464' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontscrubdatetimes' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+
+## Numeric Ids are scrubbed
+
+By default numeric properties (`int`, `uint`, `long`, and `ulong`) suffixed with `Id` are sanitized during verification. This is done by finding each id and taking a counter based that that specific id. That counter is then used replace the id values. This allows for repeatable tests when id are bing generated.
+
+<!-- snippet: NumericId -->
+<a id='snippet-numericid'></a>
+```cs
+[Fact]
+public Task NumericIdScrubbing()
+{
+    var target = new
+    {
+        Id = 5,
+        OtherId = 5,
+        YetAnotherId = 4
+    };
+
+    return Verifier.Verify(target);
+}
+```
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L139-L154' title='Snippet source file'>snippet source</a> | <a href='#snippet-numericid' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Results in the following:
+
+<!-- snippet: SerializationTests.NumericIdScrubbing.verified.txt -->
+<a id='snippet-SerializationTests.NumericIdScrubbing.verified.txt'></a>
+```txt
+{
+  Id: Id_1,
+  OtherId: Id_1,
+  YetAnotherId: Id_2
+}
+```
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.NumericIdScrubbing.verified.txt#L1-L5' title='Snippet source file'>snippet source</a> | <a href='#snippet-SerializationTests.NumericIdScrubbing.verified.txt' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+To disable this globally use:
+
+<!-- snippet: DisableNumericIdGlobal -->
+<a id='snippet-disablenumericidglobal'></a>
+```cs
+[Fact]
+public Task NumericIdScrubbingDisabled()
+{
+    var target = new
+    {
+        Id = 5,
+        OtherId = 5,
+        YetAnotherId = 4
+    };
+    return Verifier.Verify(target)
+        .ModifySerialization(settings => settings.DontScrubNumericIds());
+}
+```
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L109-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-disablenumericidglobal' title='Start of snippet'>anchor</a></sup>
+<a id='snippet-disablenumericidglobal-1'></a>
+```cs
+[Fact]
+public Task NumericIdScrubbingDisabledGlobal()
+{
+    VerifierSettings.ModifySerialization(settings => settings.DontScrubNumericIds());
+    return Verifier.Verify(
+            new
+            {
+                Id = 5,
+                OtherId = 5,
+                YetAnotherId = 4
+            });
+}
+```
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L124-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-disablenumericidglobal-1' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+To disable this behavior globally use:
+
+<!-- snippet: DisableNumericIdGlobal -->
+<a id='snippet-disablenumericidglobal'></a>
+```cs
+[Fact]
+public Task NumericIdScrubbingDisabled()
+{
+    var target = new
+    {
+        Id = 5,
+        OtherId = 5,
+        YetAnotherId = 4
+    };
+    return Verifier.Verify(target)
+        .ModifySerialization(settings => settings.DontScrubNumericIds());
+}
+```
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L109-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-disablenumericidglobal' title='Start of snippet'>anchor</a></sup>
+<a id='snippet-disablenumericidglobal-1'></a>
+```cs
+[Fact]
+public Task NumericIdScrubbingDisabledGlobal()
+{
+    VerifierSettings.ModifySerialization(settings => settings.DontScrubNumericIds());
+    return Verifier.Verify(
+            new
+            {
+                Id = 5,
+                OtherId = 5,
+                YetAnotherId = 4
+            });
+}
+```
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L124-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-disablenumericidglobal-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -228,7 +340,7 @@ To disable this behavior globally use:
 ```cs
 VerifierSettings.ModifySerialization(_ => _.DontIgnoreFalse());
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L422-L426' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontignorefalse' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L469-L473' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontignorefalse' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -382,7 +494,7 @@ public Task ScopedSerializerFluent()
             _ => { _.TypeNameHandling = TypeNameHandling.All; });
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1446-L1475' title='Snippet source file'>snippet source</a> | <a href='#snippet-scopedserializer' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1493-L1522' title='Snippet source file'>snippet source</a> | <a href='#snippet-scopedserializer' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:
@@ -445,7 +557,7 @@ public Task IgnoreTypeFluent()
 
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L896-L936' title='Snippet source file'>snippet source</a> | <a href='#snippet-addignoretype' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L943-L983' title='Snippet source file'>snippet source</a> | <a href='#snippet-addignoretype' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:
@@ -509,7 +621,7 @@ public Task AddIgnoreInstanceFluent()
             _ => { _.IgnoreInstance<Instance>(x => x.Property == "Ignore"); });
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L842-L883' title='Snippet source file'>snippet source</a> | <a href='#snippet-addignoreinstance' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L889-L930' title='Snippet source file'>snippet source</a> | <a href='#snippet-addignoreinstance' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:
@@ -553,7 +665,7 @@ public Task WithObsoleteProp()
     return Verifier.Verify(target);
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1407-L1428' title='Snippet source file'>snippet source</a> | <a href='#snippet-withobsoleteprop' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1454-L1475' title='Snippet source file'>snippet source</a> | <a href='#snippet-withobsoleteprop' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:
@@ -601,7 +713,7 @@ public Task WithObsoletePropIncludedFluent()
         .ModifySerialization(_ => { _.IncludeObsoletes(); });
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1378-L1405' title='Snippet source file'>snippet source</a> | <a href='#snippet-withobsoletepropincluded' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1425-L1452' title='Snippet source file'>snippet source</a> | <a href='#snippet-withobsoletepropincluded' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:
@@ -666,7 +778,7 @@ public Task IgnoreMemberByExpressionFluent()
         });
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1024-L1067' title='Snippet source file'>snippet source</a> | <a href='#snippet-ignorememberbyexpression' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1071-L1114' title='Snippet source file'>snippet source</a> | <a href='#snippet-ignorememberbyexpression' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:
@@ -734,7 +846,7 @@ public Task IgnoreMemberByNameFluent()
         });
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1117-L1164' title='Snippet source file'>snippet source</a> | <a href='#snippet-ignorememberbyname' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1164-L1211' title='Snippet source file'>snippet source</a> | <a href='#snippet-ignorememberbyname' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:
@@ -780,7 +892,7 @@ public Task CustomExceptionPropFluent()
         .ModifySerialization(_ => _.IgnoreMembersThatThrow<CustomException>());
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1278-L1297' title='Snippet source file'>snippet source</a> | <a href='#snippet-ignoremembersthatthrow' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1325-L1344' title='Snippet source file'>snippet source</a> | <a href='#snippet-ignoremembersthatthrow' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:
@@ -820,7 +932,7 @@ public Task ExceptionMessagePropFluent()
             _ => _.IgnoreMembersThatThrow<Exception>(x => x.Message == "Ignore"));
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L788-L812' title='Snippet source file'>snippet source</a> | <a href='#snippet-ignoremembersthatthrowexpression' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L835-L859' title='Snippet source file'>snippet source</a> | <a href='#snippet-ignoremembersthatthrowexpression' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:

--- a/readme.md
+++ b/readme.md
@@ -289,7 +289,7 @@ public Task VerifyJsonJToken()
     return Verifier.VerifyJson(target);
 }
 ```
-<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1217-L1242' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifyjson' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1264-L1289' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifyjson' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;xUnit1026;xUnit1013</NoWarn>
-    <Version>11.11.0</Version>
+    <Version>11.12.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>Json, Testing, Verify, Snapshot, Approvals</PackageTags>
     <Description>Enables verification of complex models and documents.</Description>

--- a/src/Verify.Tests/Serialization/SerializationTests.NumericIdScrubbing.verified.txt
+++ b/src/Verify.Tests/Serialization/SerializationTests.NumericIdScrubbing.verified.txt
@@ -1,0 +1,5 @@
+{
+  Id: Id_1,
+  OtherId: Id_1,
+  YetAnotherId: Id_2
+}

--- a/src/Verify.Tests/Serialization/SerializationTests.NumericIdScrubbingDisabled.verified.txt
+++ b/src/Verify.Tests/Serialization/SerializationTests.NumericIdScrubbingDisabled.verified.txt
@@ -1,0 +1,5 @@
+{
+  Id: 5,
+  OtherId: 5,
+  YetAnotherId: 4
+}

--- a/src/Verify.Tests/Serialization/SerializationTests.NumericIdScrubbingDisabledGlobal.verified.txt
+++ b/src/Verify.Tests/Serialization/SerializationTests.NumericIdScrubbingDisabledGlobal.verified.txt
@@ -1,0 +1,5 @@
+﻿{
+  Id: 5,
+  OtherId: 5,
+  YetAnotherId: 4
+}

--- a/src/Verify.Tests/Serialization/SerializationTests.cs
+++ b/src/Verify.Tests/Serialization/SerializationTests.cs
@@ -106,30 +106,52 @@ public class SerializationTests
             .ModifySerialization(settings => settings.DontScrubDateTimes());
     }
 
-    [Fact]
-    public Task NumericIdScrubbing()
-    {
-        return Verifier.Verify(
-                new
-                {
-                    Id = 1,
-                    OtherId = 1,
-                    YetAnotherId = 2
-                });
-    }
-
+    #region DisableNumericIdGlobal
     [Fact]
     public Task NumericIdScrubbingDisabled()
     {
+        var target = new
+        {
+            Id = 5,
+            OtherId = 5,
+            YetAnotherId = 4
+        };
+        return Verifier.Verify(target)
+            .ModifySerialization(settings => settings.DontScrubNumericIds());
+    }
+    #endregion
+
+    #region DisableNumericIdGlobal
+    [Fact]
+    public Task NumericIdScrubbingDisabledGlobal()
+    {
+        VerifierSettings.ModifySerialization(settings => settings.DontScrubNumericIds());
         return Verifier.Verify(
                 new
                 {
-                    Id = 1,
-                    OtherId = 1,
-                    YetAnotherId = 2
-                })
-            .ModifySerialization(settings => settings.DontScrubNumericIds());
+                    Id = 5,
+                    OtherId = 5,
+                    YetAnotherId = 4
+                });
     }
+    #endregion
+
+    #region NumericId
+
+    [Fact]
+    public Task NumericIdScrubbing()
+    {
+        var target = new
+        {
+            Id = 5,
+            OtherId = 5,
+            YetAnotherId = 4
+        };
+
+        return Verifier.Verify(target);
+    }
+
+    #endregion
 
     [Fact]
     public void SettingsIsCloned()

--- a/src/Verify.Tests/Serialization/SerializationTests.cs
+++ b/src/Verify.Tests/Serialization/SerializationTests.cs
@@ -107,6 +107,31 @@ public class SerializationTests
     }
 
     [Fact]
+    public Task NumericIdScrubbing()
+    {
+        return Verifier.Verify(
+                new
+                {
+                    Id = 1,
+                    OtherId = 1,
+                    YetAnotherId = 2
+                });
+    }
+
+    [Fact]
+    public Task NumericIdScrubbingDisabled()
+    {
+        return Verifier.Verify(
+                new
+                {
+                    Id = 1,
+                    OtherId = 1,
+                    YetAnotherId = 2
+                })
+            .ModifySerialization(settings => settings.DontScrubNumericIds());
+    }
+
+    [Fact]
     public void SettingsIsCloned()
     {
         SerializationSettings settings = new();

--- a/src/Verify/Counters/CounterContext.cs
+++ b/src/Verify/Counters/CounterContext.cs
@@ -8,6 +8,14 @@
  {
      static AsyncLocal<CounterContext?> local = new();
 
+     ConcurrentDictionary<object, int> idCache = new();
+     int currentId;
+
+     public int NextId(object input)
+     {
+         return idCache.GetOrAdd(input, _ => Interlocked.Increment(ref currentId));
+     }
+
      ConcurrentDictionary<Guid, int> guidCache = new();
      int currentGuid;
 

--- a/src/Verify/Serialization/Converters/IdConverter.cs
+++ b/src/Verify/Serialization/Converters/IdConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using VerifyTests;
+
+class IdConverter :
+    WriteOnlyJsonConverter
+{
+    public override bool CanConvert(Type objectType)
+    {
+        return true;
+    }
+
+    public override void WriteJson(
+        JsonWriter writer,
+        object value,
+        JsonSerializer serializer,
+        IReadOnlyDictionary<string, object> context)
+    {
+        var id = CounterContext.Current.NextId(value);
+        writer.WriteValue($"Id_{id}");
+    }
+}

--- a/src/Verify/Serialization/CustomContractResolver.cs
+++ b/src/Verify/Serialization/CustomContractResolver.cs
@@ -12,6 +12,7 @@ class CustomContractResolver :
     bool ignoreEmptyCollections;
     bool ignoreFalse;
     bool includeObsoletes;
+    bool scrubNumericIds;
     IReadOnlyDictionary<Type, List<string>> ignoredMembers;
     IReadOnlyList<string> ignoredByNameMembers;
     IReadOnlyList<Type> ignoredTypes;
@@ -24,6 +25,7 @@ class CustomContractResolver :
         bool ignoreEmptyCollections,
         bool ignoreFalse,
         bool includeObsoletes,
+        bool scrubNumericIds,
         IReadOnlyDictionary<Type, List<string>> ignoredMembers,
         IReadOnlyList<string> ignoredByNameMembers,
         IReadOnlyList<Type> ignoredTypes,
@@ -38,6 +40,7 @@ class CustomContractResolver :
         this.ignoreEmptyCollections = ignoreEmptyCollections;
         this.ignoreFalse = ignoreFalse;
         this.includeObsoletes = includeObsoletes;
+        this.scrubNumericIds = scrubNumericIds;
         this.ignoredMembers = ignoredMembers;
         this.ignoredByNameMembers = ignoredByNameMembers;
         this.ignoredTypes = ignoredTypes;
@@ -158,6 +161,20 @@ class CustomContractResolver :
             return property;
         }
 
+        if (scrubNumericIds && member.Name.EndsWith("Id"))
+        {
+            if (
+                propertyType == typeof(int) ||
+                propertyType == typeof(long) ||
+                propertyType == typeof(uint) ||
+                propertyType == typeof(ulong)
+                )
+            {
+                property.Converter = new IdConverter();
+                return property;
+            }
+
+        }
         if (ignoredInstances.TryGetValue(propertyType, out var funcs))
         {
             property.ShouldSerialize = declaringInstance =>

--- a/src/Verify/Serialization/Scrubbers/SharedScrubber.cs
+++ b/src/Verify/Serialization/Scrubbers/SharedScrubber.cs
@@ -9,15 +9,13 @@ class SharedScrubber
     internal static List<string> datetimeFormats = new();
     internal static List<string> datetimeOffsetFormats = new();
     bool scrubGuids;
-    bool scrubNumericIds;
     bool scrubDateTimes;
     JsonSerializerSettings settings;
 
-    public SharedScrubber(bool scrubGuids, bool scrubDateTimes, bool scrubNumericIds, JsonSerializerSettings settings)
+    public SharedScrubber(bool scrubGuids, bool scrubDateTimes, JsonSerializerSettings settings)
     {
         this.scrubGuids = scrubGuids;
         this.scrubDateTimes = scrubDateTimes;
-        this.scrubNumericIds = scrubNumericIds;
         this.settings = settings;
     }
 

--- a/src/Verify/Serialization/Scrubbers/SharedScrubber.cs
+++ b/src/Verify/Serialization/Scrubbers/SharedScrubber.cs
@@ -9,16 +9,18 @@ class SharedScrubber
     internal static List<string> datetimeFormats = new();
     internal static List<string> datetimeOffsetFormats = new();
     bool scrubGuids;
+    bool scrubNumericIds;
     bool scrubDateTimes;
     JsonSerializerSettings settings;
     static Func<Guid, int> intOrNextGuid = input => CounterContext.Current.NextGuid(input);
     static Func<DateTime, int> intOrNextDateTime = input => CounterContext.Current.NextDateTime(input);
     static Func<DateTimeOffset, int> intOrNextDateTimeOffset = input => CounterContext.Current.NextDateTimeOffset(input);
 
-    public SharedScrubber(bool scrubGuids, bool scrubDateTimes, JsonSerializerSettings settings)
+    public SharedScrubber(bool scrubGuids, bool scrubDateTimes, bool scrubNumericIds, JsonSerializerSettings settings)
     {
         this.scrubGuids = scrubGuids;
         this.scrubDateTimes = scrubDateTimes;
+        this.scrubNumericIds = scrubNumericIds;
         this.settings = settings;
     }
 

--- a/src/Verify/Serialization/SerializationSettings.cs
+++ b/src/Verify/Serialization/SerializationSettings.cs
@@ -69,6 +69,7 @@ namespace VerifyTests
                         x => x.Key,
                         x => x.Value.Clone()),
                 scrubDateTimes = scrubDateTimes,
+                scrubNumericIds = scrubNumericIds,
                 scrubGuids = scrubGuids,
                 includeObsoletes = includeObsoletes,
             };
@@ -114,6 +115,13 @@ namespace VerifyTests
             scrubDateTimes = false;
         }
 
+        bool scrubNumericIds= true;
+
+        public void DontScrubNumericIds()
+        {
+            scrubNumericIds = false;
+        }
+
         public JsonSerializerSettings BuildSettings()
         {
             #region defaultSerialization
@@ -128,7 +136,7 @@ namespace VerifyTests
             #endregion
 
             settings.SerializationBinder = new ShortNameBinder();
-            SharedScrubber scrubber = new(scrubGuids, scrubDateTimes, settings);
+            SharedScrubber scrubber = new(scrubGuids, scrubDateTimes, scrubNumericIds, settings);
             settings.ContractResolver = new CustomContractResolver(
                 ignoreEmptyCollections,
                 ignoreFalse,

--- a/src/Verify/Serialization/SerializationSettings.cs
+++ b/src/Verify/Serialization/SerializationSettings.cs
@@ -136,11 +136,12 @@ namespace VerifyTests
             #endregion
 
             settings.SerializationBinder = new ShortNameBinder();
-            SharedScrubber scrubber = new(scrubGuids, scrubDateTimes, scrubNumericIds, settings);
+            SharedScrubber scrubber = new(scrubGuids, scrubDateTimes, settings);
             settings.ContractResolver = new CustomContractResolver(
                 ignoreEmptyCollections,
                 ignoreFalse,
                 includeObsoletes,
+                scrubNumericIds,
                 ignoredMembers,
                 ignoredByNameMembers,
                 ignoreMembersWithType,


### PR DESCRIPTION

By default numeric properties (`int`, `uint`, `long`, and `ulong`) suffixed with `Id` are sanitized during verification. This is done by finding each id and taking a counter based that that specific id. That counter is then used replace the id values. This allows for repeatable tests when id are bing generated.

<!-- snippet: NumericId -->
<a id='snippet-numericid'></a>
```cs
[Fact]
public Task NumericIdScrubbing()
{
    var target = new
    {
        Id = 5,
        OtherId = 5,
        YetAnotherId = 4
    };

    return Verifier.Verify(target);
}
```
<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L139-L154' title='Snippet source file'>snippet source</a> | <a href='#snippet-numericid' title='Start of snippet'>anchor</a></sup>
<!-- endSnippet -->

Results in the following:

<!-- snippet: SerializationTests.NumericIdScrubbing.verified.txt -->
<a id='snippet-SerializationTests.NumericIdScrubbing.verified.txt'></a>
```txt
{
  Id: Id_1,
  OtherId: Id_1,
  YetAnotherId: Id_2
}
```
<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.NumericIdScrubbing.verified.txt#L1-L5' title='Snippet source file'>snippet source</a> | <a href='#snippet-SerializationTests.NumericIdScrubbing.verified.txt' title='Start of snippet'>anchor</a></sup>
<!-- endSnippet -->

To disable this globally use:

<!-- snippet: DisableNumericIdGlobal -->
<a id='snippet-disablenumericidglobal'></a>
```cs
[Fact]
public Task NumericIdScrubbingDisabled()
{
    var target = new
    {
        Id = 5,
        OtherId = 5,
        YetAnotherId = 4
    };
    return Verifier.Verify(target)
        .ModifySerialization(settings => settings.DontScrubNumericIds());
}
```
<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L109-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-disablenumericidglobal' title='Start of snippet'>anchor</a></sup>
<a id='snippet-disablenumericidglobal-1'></a>
```cs
[Fact]
public Task NumericIdScrubbingDisabledGlobal()
{
    VerifierSettings.ModifySerialization(settings => settings.DontScrubNumericIds());
    return Verifier.Verify(
            new
            {
                Id = 5,
                OtherId = 5,
                YetAnotherId = 4
            });
}
```
<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L124-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-disablenumericidglobal-1' title='Start of snippet'>anchor</a></sup>
<!-- endSnippet -->

To disable this behavior globally use:

<!-- snippet: DisableNumericIdGlobal -->
<a id='snippet-disablenumericidglobal'></a>
```cs
[Fact]
public Task NumericIdScrubbingDisabled()
{
    var target = new
    {
        Id = 5,
        OtherId = 5,
        YetAnotherId = 4
    };
    return Verifier.Verify(target)
        .ModifySerialization(settings => settings.DontScrubNumericIds());
}
```
<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L109-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-disablenumericidglobal' title='Start of snippet'>anchor</a></sup>
<a id='snippet-disablenumericidglobal-1'></a>
```cs
[Fact]
public Task NumericIdScrubbingDisabledGlobal()
{
    VerifierSettings.ModifySerialization(settings => settings.DontScrubNumericIds());
    return Verifier.Verify(
            new
            {
                Id = 5,
                OtherId = 5,
                YetAnotherId = 4
            });
}
```
<sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L124-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-disablenumericidglobal-1' title='Start of snippet'>anchor</a></sup>
<!-- endSnippet -->
