### PR TITLE
Fix typo (dup) in converters doc

### DIFF
--- a/docs/mdsource/converter.source.md
+++ b/docs/mdsource/converter.source.md
@@ -2,7 +2,7 @@
 
 Converters are used to split a target into its component parts, then verify each of those parts.
 
-When a target is split the result the result is:
+When a target is split the result is:
 
  * An info file (containing the metadata of the target) serialized as json. File name: `{TestType}.{TestMethod}.info.verified.txt`
  * Zero or more documents of a specified extension. File name: `{TestType}.{TestMethod}.{Index}.verified.{Extension}`


### PR DESCRIPTION
Removes “the result” that was repeated.