### PR TITLE
Allow user to sort serialized properties alphabetically

### DIFF
--- a/src/Verify.Tests/Serialization/SerializationTests.SortingPropertiesAlphabeticallyDoesNotAffectTypeName.verified.txt
+++ b/src/Verify.Tests/Serialization/SerializationTests.SortingPropertiesAlphabeticallyDoesNotAffectTypeName.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  $type: Person,
+  Address: {
+    $type: Address,
+    Country: USA,
+    Street: 1 Puddle Lane
+  },
+  Children: {
+    $type: List<string>,
+    $values: [
+      Sam,
+      Mary
+    ]
+  },
+  FamilyName: Smith,
+  GivenNames: John,
+  Id: Guid_1,
+  Spouse: Jill
+}

--- a/src/Verify.Tests/Serialization/SerializationTests.SortsPropertiesAlphabetically.verified.txt
+++ b/src/Verify.Tests/Serialization/SerializationTests.SortsPropertiesAlphabetically.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Address: {
+    Country: USA,
+    Street: 1 Puddle Lane
+  },
+  Children: [
+    Sam,
+    Mary
+  ],
+  FamilyName: Smith,
+  GivenNames: John,
+  Id: Guid_1,
+  Spouse: Jill
+}

--- a/src/Verify.Tests/Serialization/SerializationTests.cs
+++ b/src/Verify.Tests/Serialization/SerializationTests.cs
@@ -1750,4 +1750,48 @@ public class SerializationTests
     }
 
     #endregion
+
+    [Fact]
+    public Task SortsPropertiesAlphabetically()
+    {
+        var person = new Person
+        {
+            Id = Guid.NewGuid(),
+            Title = Title.Mr,
+            GivenNames = "John",
+            FamilyName = "Smith",
+            Spouse = "Jill",
+            Children = new() { "Sam", "Mary" },
+            Address = new()
+            {
+                Street = "1 Puddle Lane",
+                Country = "USA"
+            }
+        };
+        return Verifier.Verify(person)
+            .ModifySerialization(s => s.SortPropertiesAlphabetically());
+    }
+
+    [Fact]
+    public Task SortingPropertiesAlphabeticallyDoesNotAffectTypeName()
+    {
+        var person = new Person
+        {
+            Id = Guid.NewGuid(),
+            Title = Title.Mr,
+            GivenNames = "John",
+            FamilyName = "Smith",
+            Spouse = "Jill",
+            Children = new() { "Sam", "Mary" },
+            Address = new()
+            {
+                Street = "1 Puddle Lane",
+                Country = "USA"
+            }
+        };
+        return Verifier.Verify(person)
+            .ModifySerialization(s => s.SortPropertiesAlphabetically())
+            .AddExtraSettings(
+                _ => { _.TypeNameHandling = TypeNameHandling.All; });
+    }
 }

--- a/src/Verify.Tests/Serialization/SerializationTests.cs
+++ b/src/Verify.Tests/Serialization/SerializationTests.cs
@@ -22,7 +22,7 @@ using Xunit;
 #pragma warning disable CS8618
 
 [UsesVerify]
-public class SerializationTests
+public class SerializationTests : IDisposable
 {
     [ModuleInitializer]
     public static void Initialize()
@@ -1833,8 +1833,9 @@ void CustomExceptionPropGlobal()
                 Country = "USA"
             }
         };
-        return Verifier.Verify(person)
-            .ModifySerialization(s => s.SortPropertiesAlphabetically());
+
+        VerifierSettings.SortPropertiesAlphabetically();
+        return Verifier.Verify(person);
     }
 
     [Fact]
@@ -1854,9 +1855,15 @@ void CustomExceptionPropGlobal()
                 Country = "USA"
             }
         };
+
+        VerifierSettings.SortPropertiesAlphabetically();
         return Verifier.Verify(person)
-            .ModifySerialization(s => s.SortPropertiesAlphabetically())
             .AddExtraSettings(
                 _ => { _.TypeNameHandling = TypeNameHandling.All; });
+    }
+
+    public void Dispose()
+    {
+        VerifierSettings.DontSortPropertiesAlphabetically();
     }
 }

--- a/src/Verify/Serialization/CustomContractResolver.cs
+++ b/src/Verify/Serialization/CustomContractResolver.cs
@@ -13,6 +13,7 @@ class CustomContractResolver :
     bool ignoreFalse;
     bool includeObsoletes;
     bool scrubNumericIds;
+    bool sortPropertiesAlphabetically;
     IReadOnlyDictionary<Type, List<string>> ignoredMembers;
     IReadOnlyList<string> ignoredByNameMembers;
     IReadOnlyList<Type> ignoredTypes;
@@ -26,6 +27,7 @@ class CustomContractResolver :
         bool ignoreFalse,
         bool includeObsoletes,
         bool scrubNumericIds,
+        bool sortPropertiesAlphabetically,
         IReadOnlyDictionary<Type, List<string>> ignoredMembers,
         IReadOnlyList<string> ignoredByNameMembers,
         IReadOnlyList<Type> ignoredTypes,
@@ -38,6 +40,7 @@ class CustomContractResolver :
         this.ignoreFalse = ignoreFalse;
         this.includeObsoletes = includeObsoletes;
         this.scrubNumericIds = scrubNumericIds;
+        this.sortPropertiesAlphabetically = sortPropertiesAlphabetically;
         this.ignoredMembers = ignoredMembers;
         this.ignoredByNameMembers = ignoredByNameMembers;
         this.ignoredTypes = ignoredTypes;
@@ -74,7 +77,15 @@ class CustomContractResolver :
                     Writable = false,
                 });
         }
-
+        
+        if (sortPropertiesAlphabetically)
+        {
+            properties = properties
+                .OrderBy(p => p.Order ?? -1) // Still honor explicit ordering
+                .ThenBy(p => p.PropertyName, StringComparer.Ordinal)
+                .ToList();
+        }
+        
         return properties;
     }
 

--- a/src/Verify/Serialization/CustomContractResolver.cs
+++ b/src/Verify/Serialization/CustomContractResolver.cs
@@ -13,7 +13,6 @@ class CustomContractResolver :
     bool ignoreFalse;
     bool includeObsoletes;
     bool scrubNumericIds;
-    bool sortPropertiesAlphabetically;
     IReadOnlyDictionary<Type, List<string>> ignoredMembers;
     IReadOnlyList<string> ignoredByNameMembers;
     IReadOnlyList<Type> ignoredTypes;
@@ -27,7 +26,6 @@ class CustomContractResolver :
         bool ignoreFalse,
         bool includeObsoletes,
         bool scrubNumericIds,
-        bool sortPropertiesAlphabetically,
         IReadOnlyDictionary<Type, List<string>> ignoredMembers,
         IReadOnlyList<string> ignoredByNameMembers,
         IReadOnlyList<Type> ignoredTypes,
@@ -40,7 +38,6 @@ class CustomContractResolver :
         this.ignoreFalse = ignoreFalse;
         this.includeObsoletes = includeObsoletes;
         this.scrubNumericIds = scrubNumericIds;
-        this.sortPropertiesAlphabetically = sortPropertiesAlphabetically;
         this.ignoredMembers = ignoredMembers;
         this.ignoredByNameMembers = ignoredByNameMembers;
         this.ignoredTypes = ignoredTypes;
@@ -78,7 +75,7 @@ class CustomContractResolver :
                 });
         }
         
-        if (sortPropertiesAlphabetically)
+        if (VerifierSettings.sortPropertiesAlphabetically)
         {
             properties = properties
                 .OrderBy(p => p.Order ?? -1) // Still honor explicit ordering

--- a/src/Verify/Serialization/SerializationSettings.cs
+++ b/src/Verify/Serialization/SerializationSettings.cs
@@ -76,6 +76,7 @@ namespace VerifyTests
                 scrubNumericIds = scrubNumericIds,
                 scrubGuids = scrubGuids,
                 includeObsoletes = includeObsoletes,
+                sortPropertiesAlphabetically = sortPropertiesAlphabetically,
             };
         }
 
@@ -143,6 +144,7 @@ namespace VerifyTests
                 ignoreFalse,
                 includeObsoletes,
                 scrubNumericIds,
+                sortPropertiesAlphabetically,
                 ignoredMembers,
                 ignoredByNameMembers,
                 ignoreMembersWithType,
@@ -209,6 +211,13 @@ namespace VerifyTests
         public void IncludeObsoletes()
         {
             includeObsoletes = true;
+        }
+
+        bool sortPropertiesAlphabetically;
+
+        public void SortPropertiesAlphabetically()
+        {
+            sortPropertiesAlphabetically = true;
         }
     }
 }

--- a/src/Verify/Serialization/SerializationSettings.cs
+++ b/src/Verify/Serialization/SerializationSettings.cs
@@ -76,7 +76,6 @@ namespace VerifyTests
                 scrubNumericIds = scrubNumericIds,
                 scrubGuids = scrubGuids,
                 includeObsoletes = includeObsoletes,
-                sortPropertiesAlphabetically = sortPropertiesAlphabetically,
             };
         }
 
@@ -144,7 +143,6 @@ namespace VerifyTests
                 ignoreFalse,
                 includeObsoletes,
                 scrubNumericIds,
-                sortPropertiesAlphabetically,
                 ignoredMembers,
                 ignoredByNameMembers,
                 ignoreMembersWithType,
@@ -211,13 +209,6 @@ namespace VerifyTests
         public void IncludeObsoletes()
         {
             includeObsoletes = true;
-        }
-
-        bool sortPropertiesAlphabetically;
-
-        public void SortPropertiesAlphabetically()
-        {
-            sortPropertiesAlphabetically = true;
         }
     }
 }

--- a/src/Verify/Serialization/VerifierSettings.cs
+++ b/src/Verify/Serialization/VerifierSettings.cs
@@ -195,5 +195,17 @@ namespace VerifyTests
         {
             scrubSolutionDirectory = false;
         }
+
+        internal static bool sortPropertiesAlphabetically;
+
+        public static void SortPropertiesAlphabetically()
+        {
+            sortPropertiesAlphabetically = true;
+        }
+
+        public static void DontSortPropertiesAlphabetically()
+        {
+            sortPropertiesAlphabetically = false;
+        }
     }
 }


### PR DESCRIPTION
As discussed in [this issue](https://github.com/VerifyTests/Verify/issues/396#issuecomment-915913731), I think it's useful to allow the user to enforce a consistent, alphabetical ordering of properties in the serialized data. A simple scenario that comes to mind is reordering members within a class, which would currently cause all corresponding tests to fail.

I've started with the most simple way to implement this (including a few tests). Please let me know what's missing.