### PR TITLE
Change Verify.props to fix compile problems

### DIFF
--- a/src/Verify/buildTransitive/Verify.props
+++ b/src/Verify/buildTransitive/Verify.props
@@ -6,7 +6,7 @@
     <AttributesFile>Verify.Attributes$(MSBuildProjectExtension.Replace('proj', ''))</AttributesFile>
   </PropertyGroup>
   <Target Name="WriteVerifyAttributes"
-          Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#' or '$(Language)' == 'F#'"
+          Condition="$(Language) == 'VB' or $(Language) == 'C#' or $(Language) == 'F#'"
           BeforeTargets="BeforeCompile;CoreCompile"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(IntermediateOutputPath)$(AttributesFile)">
@@ -29,8 +29,8 @@
     <WriteCodeFragment AssemblyAttributes="@(Attributes)"
                        Language="$(Language)"
                        OutputFile="$(AttributesFilePath)">
-      <Output TaskParameter="OutputFile" ItemName="Compile" Condition="'$(Language)' != 'F#'" />
-      <Output TaskParameter="OutputFile" ItemName="CompileBefore" Condition="'$(Language)' == 'F#'" />
+      <Output TaskParameter="OutputFile" ItemName="Compile" Condition="$(Language) != 'F#'" />
+      <Output TaskParameter="OutputFile" ItemName="CompileBefore" Condition="$(Language) == 'F#'" />
       <Output TaskParameter="OutputFile" ItemName="FileWrites" />
     </WriteCodeFragment>
   </Target>


### PR DESCRIPTION
Adding the single quotes seems to fix issues with compiling in Visual Studio 2019.

This is to fix issue #423 