### PR TITLE
add OmitContentFromException

### DIFF
--- a/docs/mdsource/verify-options.source.md
+++ b/docs/mdsource/verify-options.source.md
@@ -14,10 +14,15 @@ snippet: AutoVerify
 Note that auto accepted changes in `.verified.` files remain visible in source control tooling.
 
 
-### OnHandlers
+## OnHandlers
 
  * `OnVerify` takes two actions that are called before and after each verification.
  * `OnFirstVerify` is called when there is no verified file.
  * `OnVerifyMismatch` is called when a received file does not match the existing verified file.
 
 snippet: OnHandlers
+
+
+## OmitContentFromException
+
+By default, when a verify mismatch occurs for text, the content of the received and verified files is included in the exception that is thrown. This results in that text being included in test runners and build output. To omit the content use `VerifierSettings.OmitContentFromException`.

--- a/docs/verify-options.md
+++ b/docs/verify-options.md
@@ -28,7 +28,7 @@ settings.AutoVerify();
 Note that auto accepted changes in `.verified.` files remain visible in source control tooling.
 
 
-### OnHandlers
+## OnHandlers
 
  * `OnVerify` takes two actions that are called before and after each verification.
  * `OnFirstVerify` is called when there is no verified file.
@@ -61,3 +61,8 @@ public Task OnHandlersSample()
 ```
 <sup><a href='/src/Verify.Tests/Snippets/Snippets.cs#L7-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-onhandlers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+
+## OmitContentFromException
+
+By default, when a verify mismatch occurs for text, the content of the received and verified files is included in the exception that is thrown. This results in that text being included in test runners and build output. To omit the content use `VerifierSettings.OmitContentFromException`.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;xUnit1026;xUnit1013;msb3277;CS0436</NoWarn>
-    <Version>14.7.1</Version>
+    <Version>14.8.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>

--- a/src/OmitContentFromException/OmitContentFromException.csproj
+++ b/src/OmitContentFromException/OmitContentFromException.csproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="ProjectDefaults" Version="1.0.62" PrivateAssets="all" />
+    <ProjectReference Include="..\Verify.Xunit\Verify.Xunit.csproj" />
+    <ProjectReference Include="..\Verify\Verify.csproj" />
+  </ItemGroup>
+  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
+  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
+  <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
+</Project>

--- a/src/OmitContentFromException/OmitContentFromExceptionTests.String.verified.txt
+++ b/src/OmitContentFromException/OmitContentFromExceptionTests.String.verified.txt
@@ -1,0 +1,5 @@
+﻿Results do not match.
+Use DiffEngineTray to verify files.
+Differences:
+Received: OmitContentFromExceptionTests.String.received.txt
+Verified: OmitContentFromExceptionTests.String.verified.txt

--- a/src/OmitContentFromException/OmitContentFromExceptionTests.String.verified.txt
+++ b/src/OmitContentFromException/OmitContentFromExceptionTests.String.verified.txt
@@ -1,5 +1,4 @@
 ﻿Results do not match.
-Use DiffEngineTray to verify files.
 Differences:
 Received: OmitContentFromExceptionTests.String.received.txt
 Verified: OmitContentFromExceptionTests.String.verified.txt

--- a/src/OmitContentFromException/OmitContentFromExceptionTests.cs
+++ b/src/OmitContentFromException/OmitContentFromExceptionTests.cs
@@ -16,7 +16,7 @@ public class OmitContentFromExceptionTests
         }
         catch (Exception exception)
         {
-            await Verifier.Verify(exception.Message);
+            await Verifier.Verify(exception.Message).ScrubLinesContaining("DiffEngineTray");
         }
     }
 }

--- a/src/OmitContentFromException/OmitContentFromExceptionTests.cs
+++ b/src/OmitContentFromException/OmitContentFromExceptionTests.cs
@@ -1,0 +1,22 @@
+﻿[UsesVerify]
+public class OmitContentFromExceptionTests
+{
+    static OmitContentFromExceptionTests()
+    {
+        VerifierSettings.OmitContentFromException();
+        VerifierSettings.DisableRequireUniquePrefix();
+    }
+
+    [Fact]
+    public async Task String()
+    {
+        try
+        {
+            await Verifier.Verify("Foo").DisableDiff();
+        }
+        catch (Exception exception)
+        {
+            await Verifier.Verify(exception.Message);
+        }
+    }
+}

--- a/src/Verify.sln
+++ b/src/Verify.sln
@@ -61,6 +61,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Verify.Expecto", "Verify.Ex
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Verify.Expecto.FSharpTests", "Verify.Expecto.FSharpTests\Verify.Expecto.FSharpTests.fsproj", "{04431E3E-56D0-4B16-8128-DA5B1D0F4689}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OmitContentFromException", "OmitContentFromException\OmitContentFromException.csproj", "{92E90960-270E-421E-A78F-5475ED2FC61C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -150,6 +152,10 @@ Global
 		{04431E3E-56D0-4B16-8128-DA5B1D0F4689}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{04431E3E-56D0-4B16-8128-DA5B1D0F4689}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{04431E3E-56D0-4B16-8128-DA5B1D0F4689}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92E90960-270E-421E-A78F-5475ED2FC61C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92E90960-270E-421E-A78F-5475ED2FC61C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92E90960-270E-421E-A78F-5475ED2FC61C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92E90960-270E-421E-A78F-5475ED2FC61C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Verify/Verifier/VerifyEngine.cs
+++ b/src/Verify/Verifier/VerifyEngine.cs
@@ -229,7 +229,8 @@ class VerifyEngine
         builder.AppendLine($"Verified: {Path.GetFileName(item.Verified)}");
         if (message is null)
         {
-            if (EmptyFiles.Extensions.IsText(item.Extension))
+            if (!VerifierSettings.omitContentFromException &&
+                EmptyFiles.Extensions.IsText(item.Extension))
             {
                 builder.AppendLine("Received Content:");
                 builder.AppendLine($"{await FileHelpers.ReadText(item.Received)}");
@@ -253,7 +254,8 @@ class VerifyEngine
         await VerifierSettings.RunOnFirstVerify(item);
 
         builder.AppendLine($"{Path.GetFileName(item.Verified)}: Empty or does not exist");
-        if (EmptyFiles.Extensions.IsText(item.Extension))
+        if (!VerifierSettings.omitContentFromException &&
+            EmptyFiles.Extensions.IsText(item.Extension))
         {
             builder.AppendLine($"{Path.GetFileName(item.Received)}");
             builder.AppendLine($"{await FileHelpers.ReadText(item.Received)}");

--- a/src/Verify/VerifierSettings.cs
+++ b/src/Verify/VerifierSettings.cs
@@ -1,0 +1,11 @@
+﻿namespace VerifyTests;
+
+public static partial class VerifierSettings
+{
+    internal static bool omitContentFromException;
+
+    public static void OmitContentFromException()
+    {
+        omitContentFromException = true;
+    }
+}


### PR DESCRIPTION
so the text content of mis-match files can be omitted from build logs and test runners