### PR TITLE
Change WriteOnlyJsonConverter.WriteJson

### DIFF
--- a/docs/serializer-settings.md
+++ b/docs/serializer-settings.md
@@ -583,16 +583,15 @@ class CompanyConverter :
     WriteOnlyJsonConverter<Company>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonWriter writer,
         Company company,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         serializer.Serialize(writer, company.Name);
     }
 }
 ```
-<sup><a href='/src/Verify.Tests/Snippets/Snippets.cs#L147-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-companyconverter' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/Snippets/Snippets.cs#L147-L161' title='Snippet source file'>snippet source</a> | <a href='#snippet-companyconverter' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 <!-- snippet: JsonConverter -->

--- a/docs/serializer-settings.md
+++ b/docs/serializer-settings.md
@@ -582,7 +582,7 @@ One common use case is to register a custom [JsonConverter](https://www.newtonso
 class CompanyConverter :
     WriteOnlyJsonConverter<Company>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         Company company,
         JsonSerializer serializer)

--- a/src/Verify.Tests/Serialization/SerializationTests.cs
+++ b/src/Verify.Tests/Serialization/SerializationTests.cs
@@ -2099,7 +2099,7 @@ public class SerializationTests
     class Converter :
         WriteOnlyJsonConverter<ConverterTarget>
     {
-        public override void WriteJson(
+        public override void Write(
             VerifyJsonWriter writer,
             ConverterTarget target,
             JsonSerializer serializer)

--- a/src/Verify.Tests/Serialization/SerializationTests.cs
+++ b/src/Verify.Tests/Serialization/SerializationTests.cs
@@ -2100,10 +2100,9 @@ public class SerializationTests
         WriteOnlyJsonConverter<ConverterTarget>
     {
         public override void WriteJson(
-            JsonWriter writer,
+            VerifyJsonWriter writer,
             ConverterTarget target,
-            JsonSerializer serializer,
-            IReadOnlyDictionary<string, object> context)
+            JsonSerializer serializer)
         {
             writer.WriteStartObject();
             writer.WritePropertyName("Name");

--- a/src/Verify.Tests/Snippets/Snippets.cs
+++ b/src/Verify.Tests/Snippets/Snippets.cs
@@ -150,10 +150,9 @@ public class Snippets
         WriteOnlyJsonConverter<Company>
     {
         public override void WriteJson(
-            JsonWriter writer,
+            VerifyJsonWriter writer,
             Company company,
-            JsonSerializer serializer,
-            IReadOnlyDictionary<string, object> context)
+            JsonSerializer serializer)
         {
             serializer.Serialize(writer, company.Name);
         }

--- a/src/Verify.Tests/Snippets/Snippets.cs
+++ b/src/Verify.Tests/Snippets/Snippets.cs
@@ -149,7 +149,7 @@ public class Snippets
     class CompanyConverter :
         WriteOnlyJsonConverter<Company>
     {
-        public override void WriteJson(
+        public override void Write(
             VerifyJsonWriter writer,
             Company company,
             JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/ClaimConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimConverter.cs
@@ -6,7 +6,7 @@ class ClaimConverter :
     WriteOnlyJsonConverter<Claim>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         Claim claim,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/ClaimConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class ClaimConverter :
     WriteOnlyJsonConverter<Claim>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         Claim claim,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/ClaimConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimConverter.cs
@@ -6,10 +6,9 @@ class ClaimConverter :
     WriteOnlyJsonConverter<Claim>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         Claim claim,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteStartObject();
 

--- a/src/Verify/Serialization/Converters/ClaimsIdentityConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimsIdentityConverter.cs
@@ -6,10 +6,9 @@ class ClaimsIdentityConverter :
     WriteOnlyJsonConverter<ClaimsIdentity>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         ClaimsIdentity identity,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteStartObject();
 

--- a/src/Verify/Serialization/Converters/ClaimsIdentityConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimsIdentityConverter.cs
@@ -6,7 +6,7 @@ class ClaimsIdentityConverter :
     WriteOnlyJsonConverter<ClaimsIdentity>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         ClaimsIdentity identity,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/ClaimsIdentityConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimsIdentityConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class ClaimsIdentityConverter :
     WriteOnlyJsonConverter<ClaimsIdentity>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         ClaimsIdentity identity,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/ClaimsPrincipalConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimsPrincipalConverter.cs
@@ -6,7 +6,7 @@ class ClaimsPrincipalConverter :
     WriteOnlyJsonConverter<ClaimsPrincipal>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         ClaimsPrincipal principal,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/ClaimsPrincipalConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimsPrincipalConverter.cs
@@ -6,10 +6,9 @@ class ClaimsPrincipalConverter :
     WriteOnlyJsonConverter<ClaimsPrincipal>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         ClaimsPrincipal principal,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         serializer.Serialize(writer, principal.Identities);
     }

--- a/src/Verify/Serialization/Converters/ClaimsPrincipalConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimsPrincipalConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class ClaimsPrincipalConverter :
     WriteOnlyJsonConverter<ClaimsPrincipal>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         ClaimsPrincipal principal,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/ConstructorInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/ConstructorInfoConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class ConstructorInfoConverter :
     WriteOnlyJsonConverter<ConstructorInfo>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         ConstructorInfo value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/ConstructorInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/ConstructorInfoConverter.cs
@@ -6,9 +6,9 @@ class ConstructorInfoConverter :
     WriteOnlyJsonConverter<ConstructorInfo>
 {
     public override void WriteJson(
-        JsonWriter writer, ConstructorInfo value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        VerifyJsonTextWriter writer,
+        ConstructorInfo value,
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.SimpleName());
     }

--- a/src/Verify/Serialization/Converters/ConstructorInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/ConstructorInfoConverter.cs
@@ -6,7 +6,7 @@ class ConstructorInfoConverter :
     WriteOnlyJsonConverter<ConstructorInfo>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         ConstructorInfo value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/DateConverter.cs
+++ b/src/Verify/Serialization/Converters/DateConverter.cs
@@ -13,7 +13,7 @@ class DateConverter :
         this.scrubber = scrubber;
     }
 
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         DateOnly value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/DateConverter.cs
+++ b/src/Verify/Serialization/Converters/DateConverter.cs
@@ -14,7 +14,7 @@ class DateConverter :
     }
 
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         DateOnly value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/DateConverter.cs
+++ b/src/Verify/Serialization/Converters/DateConverter.cs
@@ -14,10 +14,9 @@ class DateConverter :
     }
 
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         DateOnly value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         if (scrubber.TryConvert(value, out var result))
         {

--- a/src/Verify/Serialization/Converters/DateTimeConverter.cs
+++ b/src/Verify/Serialization/Converters/DateTimeConverter.cs
@@ -12,10 +12,9 @@ class DateTimeConverter :
     }
 
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         DateTime value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         if (scrubber.TryConvert(value, out var result))
         {

--- a/src/Verify/Serialization/Converters/DateTimeConverter.cs
+++ b/src/Verify/Serialization/Converters/DateTimeConverter.cs
@@ -11,7 +11,7 @@ class DateTimeConverter :
         this.scrubber = scrubber;
     }
 
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         DateTime value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/DateTimeConverter.cs
+++ b/src/Verify/Serialization/Converters/DateTimeConverter.cs
@@ -12,7 +12,7 @@ class DateTimeConverter :
     }
 
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         DateTime value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/DateTimeOffsetConverter.cs
+++ b/src/Verify/Serialization/Converters/DateTimeOffsetConverter.cs
@@ -11,7 +11,7 @@ class DateTimeOffsetConverter :
         this.scrubber = scrubber;
     }
 
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         DateTimeOffset value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/DateTimeOffsetConverter.cs
+++ b/src/Verify/Serialization/Converters/DateTimeOffsetConverter.cs
@@ -12,7 +12,7 @@ class DateTimeOffsetConverter :
     }
 
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         DateTimeOffset value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/DateTimeOffsetConverter.cs
+++ b/src/Verify/Serialization/Converters/DateTimeOffsetConverter.cs
@@ -12,10 +12,9 @@ class DateTimeOffsetConverter :
     }
 
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         DateTimeOffset value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         if (scrubber.TryConvert(value, out var result))
         {

--- a/src/Verify/Serialization/Converters/DelegateConverter.cs
+++ b/src/Verify/Serialization/Converters/DelegateConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class DelegateConverter :
     WriteOnlyJsonConverter<Delegate>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         Delegate @delegate,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/DelegateConverter.cs
+++ b/src/Verify/Serialization/Converters/DelegateConverter.cs
@@ -6,10 +6,9 @@ class DelegateConverter :
     WriteOnlyJsonConverter<Delegate>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         Delegate @delegate,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteStartObject();
         writer.WritePropertyName("Type");

--- a/src/Verify/Serialization/Converters/DelegateConverter.cs
+++ b/src/Verify/Serialization/Converters/DelegateConverter.cs
@@ -6,7 +6,7 @@ class DelegateConverter :
     WriteOnlyJsonConverter<Delegate>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         Delegate @delegate,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/DictionaryConverter.cs
+++ b/src/Verify/Serialization/Converters/DictionaryConverter.cs
@@ -33,7 +33,7 @@ class DictionaryConverter :
                definition == typeof(ReadOnlyDictionary<,>);
     }
 
-    public override void WriteJson(VerifyJsonTextWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(VerifyJsonWriter writer, object value, JsonSerializer serializer)
     {
         var type = value.GetType();
 

--- a/src/Verify/Serialization/Converters/DictionaryConverter.cs
+++ b/src/Verify/Serialization/Converters/DictionaryConverter.cs
@@ -33,7 +33,7 @@ class DictionaryConverter :
                definition == typeof(ReadOnlyDictionary<,>);
     }
 
-    public override void WriteJson(VerifyJsonWriter writer, object value, JsonSerializer serializer)
+    public override void Write(VerifyJsonWriter writer, object value, JsonSerializer serializer)
     {
         var type = value.GetType();
 

--- a/src/Verify/Serialization/Converters/DictionaryConverter.cs
+++ b/src/Verify/Serialization/Converters/DictionaryConverter.cs
@@ -33,7 +33,7 @@ class DictionaryConverter :
                definition == typeof(ReadOnlyDictionary<,>);
     }
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer, IReadOnlyDictionary<string, object> context)
+    public override void WriteJson(VerifyJsonTextWriter writer, object value, JsonSerializer serializer)
     {
         var type = value.GetType();
 

--- a/src/Verify/Serialization/Converters/DirectoryInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/DirectoryInfoConverter.cs
@@ -5,7 +5,7 @@ class DirectoryInfoConverter :
     WriteOnlyJsonConverter<DirectoryInfo>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         DirectoryInfo value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/DirectoryInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/DirectoryInfoConverter.cs
@@ -5,10 +5,9 @@ class DirectoryInfoConverter :
     WriteOnlyJsonConverter<DirectoryInfo>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         DirectoryInfo value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.ToString().Replace('\\','/'));
     }

--- a/src/Verify/Serialization/Converters/DirectoryInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/DirectoryInfoConverter.cs
@@ -4,7 +4,7 @@ using VerifyTests;
 class DirectoryInfoConverter :
     WriteOnlyJsonConverter<DirectoryInfo>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         DirectoryInfo value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/ExpressionConverter.cs
+++ b/src/Verify/Serialization/Converters/ExpressionConverter.cs
@@ -6,7 +6,7 @@ class ExpressionConverter :
     WriteOnlyJsonConverter<Expression>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         Expression value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/ExpressionConverter.cs
+++ b/src/Verify/Serialization/Converters/ExpressionConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class ExpressionConverter :
     WriteOnlyJsonConverter<Expression>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         Expression value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/ExpressionConverter.cs
+++ b/src/Verify/Serialization/Converters/ExpressionConverter.cs
@@ -6,10 +6,9 @@ class ExpressionConverter :
     WriteOnlyJsonConverter<Expression>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         Expression value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.ToString());
     }

--- a/src/Verify/Serialization/Converters/FieldInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/FieldInfoConverter.cs
@@ -6,7 +6,7 @@ class FieldInfoConverter :
     WriteOnlyJsonConverter<FieldInfo>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         FieldInfo value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/FieldInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/FieldInfoConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class FieldInfoConverter :
     WriteOnlyJsonConverter<FieldInfo>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         FieldInfo value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/FieldInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/FieldInfoConverter.cs
@@ -6,10 +6,9 @@ class FieldInfoConverter :
     WriteOnlyJsonConverter<FieldInfo>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         FieldInfo value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.SimpleName());
     }

--- a/src/Verify/Serialization/Converters/FileInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/FileInfoConverter.cs
@@ -5,10 +5,9 @@ class FileInfoConverter :
     WriteOnlyJsonConverter<FileInfo>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         FileInfo value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.ToString().Replace('\\','/'));
     }

--- a/src/Verify/Serialization/Converters/FileInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/FileInfoConverter.cs
@@ -4,7 +4,7 @@ using VerifyTests;
 class FileInfoConverter :
     WriteOnlyJsonConverter<FileInfo>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         FileInfo value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/FileInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/FileInfoConverter.cs
@@ -5,7 +5,7 @@ class FileInfoConverter :
     WriteOnlyJsonConverter<FileInfo>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         FileInfo value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/GuidConverter.cs
+++ b/src/Verify/Serialization/Converters/GuidConverter.cs
@@ -12,7 +12,7 @@ class GuidConverter :
         this.scrubber = scrubber;
     }
 
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         Guid value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/GuidConverter.cs
+++ b/src/Verify/Serialization/Converters/GuidConverter.cs
@@ -13,10 +13,9 @@ class GuidConverter :
     }
 
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         Guid value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         if (scrubber.TryConvert(value, out var result))
         {

--- a/src/Verify/Serialization/Converters/GuidConverter.cs
+++ b/src/Verify/Serialization/Converters/GuidConverter.cs
@@ -13,7 +13,7 @@ class GuidConverter :
     }
 
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         Guid value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/IdConverter.cs
+++ b/src/Verify/Serialization/Converters/IdConverter.cs
@@ -10,7 +10,7 @@ class IdConverter :
     }
 
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         object value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/IdConverter.cs
+++ b/src/Verify/Serialization/Converters/IdConverter.cs
@@ -10,10 +10,9 @@ class IdConverter :
     }
 
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         object value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         var id = CounterContext.Current.NextId(value);
         writer.WriteValue($"Id_{id}");

--- a/src/Verify/Serialization/Converters/IdConverter.cs
+++ b/src/Verify/Serialization/Converters/IdConverter.cs
@@ -9,7 +9,7 @@ class IdConverter :
         return true;
     }
 
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         object value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/JArrayConverter.cs
+++ b/src/Verify/Serialization/Converters/JArrayConverter.cs
@@ -6,10 +6,9 @@ class JArrayConverter :
     WriteOnlyJsonConverter<JArray>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         JArray value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         var list = value.ToObject<List<object>>()!;
         serializer.Serialize(writer, list);

--- a/src/Verify/Serialization/Converters/JArrayConverter.cs
+++ b/src/Verify/Serialization/Converters/JArrayConverter.cs
@@ -6,7 +6,7 @@ class JArrayConverter :
     WriteOnlyJsonConverter<JArray>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         JArray value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/JArrayConverter.cs
+++ b/src/Verify/Serialization/Converters/JArrayConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class JArrayConverter :
     WriteOnlyJsonConverter<JArray>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         JArray value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/JObjectConverter.cs
+++ b/src/Verify/Serialization/Converters/JObjectConverter.cs
@@ -6,10 +6,9 @@ class JObjectConverter :
     WriteOnlyJsonConverter<JObject>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         JObject value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         var dictionary = value.ToObject<Dictionary<string, object>>()!;
         serializer.Serialize(writer, dictionary);

--- a/src/Verify/Serialization/Converters/JObjectConverter.cs
+++ b/src/Verify/Serialization/Converters/JObjectConverter.cs
@@ -6,7 +6,7 @@ class JObjectConverter :
     WriteOnlyJsonConverter<JObject>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         JObject value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/JObjectConverter.cs
+++ b/src/Verify/Serialization/Converters/JObjectConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class JObjectConverter :
     WriteOnlyJsonConverter<JObject>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         JObject value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/MethodInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/MethodInfoConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class MethodInfoConverter :
     WriteOnlyJsonConverter<MethodInfo>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         MethodInfo value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/MethodInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/MethodInfoConverter.cs
@@ -6,10 +6,9 @@ class MethodInfoConverter :
     WriteOnlyJsonConverter<MethodInfo>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         MethodInfo value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.SimpleName());
     }

--- a/src/Verify/Serialization/Converters/MethodInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/MethodInfoConverter.cs
@@ -6,7 +6,7 @@ class MethodInfoConverter :
     WriteOnlyJsonConverter<MethodInfo>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         MethodInfo value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/NameValueCollectionConverter.cs
+++ b/src/Verify/Serialization/Converters/NameValueCollectionConverter.cs
@@ -6,10 +6,9 @@ class NameValueCollectionConverter :
     WriteOnlyJsonConverter<NameValueCollection>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         NameValueCollection collection,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         var dictionary = new Dictionary<string,string?>();
         foreach (string? key in collection)

--- a/src/Verify/Serialization/Converters/NameValueCollectionConverter.cs
+++ b/src/Verify/Serialization/Converters/NameValueCollectionConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class NameValueCollectionConverter :
     WriteOnlyJsonConverter<NameValueCollection>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         NameValueCollection collection,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/NameValueCollectionConverter.cs
+++ b/src/Verify/Serialization/Converters/NameValueCollectionConverter.cs
@@ -6,7 +6,7 @@ class NameValueCollectionConverter :
     WriteOnlyJsonConverter<NameValueCollection>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         NameValueCollection collection,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/ParameterInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/ParameterInfoConverter.cs
@@ -6,10 +6,9 @@ class ParameterInfoConverter :
     WriteOnlyJsonConverter<ParameterInfo>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         ParameterInfo value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.SimpleName());
     }

--- a/src/Verify/Serialization/Converters/ParameterInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/ParameterInfoConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class ParameterInfoConverter :
     WriteOnlyJsonConverter<ParameterInfo>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         ParameterInfo value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/ParameterInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/ParameterInfoConverter.cs
@@ -6,7 +6,7 @@ class ParameterInfoConverter :
     WriteOnlyJsonConverter<ParameterInfo>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         ParameterInfo value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/PropertyInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/PropertyInfoConverter.cs
@@ -6,7 +6,7 @@ class PropertyInfoConverter :
     WriteOnlyJsonConverter<PropertyInfo>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         PropertyInfo value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/PropertyInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/PropertyInfoConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class PropertyInfoConverter :
     WriteOnlyJsonConverter<PropertyInfo>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         PropertyInfo value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/PropertyInfoConverter.cs
+++ b/src/Verify/Serialization/Converters/PropertyInfoConverter.cs
@@ -6,10 +6,9 @@ class PropertyInfoConverter :
     WriteOnlyJsonConverter<PropertyInfo>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         PropertyInfo value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.SimpleName());
     }

--- a/src/Verify/Serialization/Converters/StringBuilderConverter.cs
+++ b/src/Verify/Serialization/Converters/StringBuilderConverter.cs
@@ -12,7 +12,7 @@ class StringBuilderConverter :
     }
 
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         StringBuilder value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/StringBuilderConverter.cs
+++ b/src/Verify/Serialization/Converters/StringBuilderConverter.cs
@@ -12,10 +12,9 @@ class StringBuilderConverter :
     }
 
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         StringBuilder value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         var stringValue = value.ToString();
         if (sharedScrubber.TryConvertString(stringValue, out var result))

--- a/src/Verify/Serialization/Converters/StringBuilderConverter.cs
+++ b/src/Verify/Serialization/Converters/StringBuilderConverter.cs
@@ -11,7 +11,7 @@ class StringBuilderConverter :
         this.sharedScrubber = sharedScrubber;
     }
 
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         StringBuilder value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/StringConverter.cs
+++ b/src/Verify/Serialization/Converters/StringConverter.cs
@@ -11,7 +11,7 @@ class StringConverter :
         this.sharedScrubber = sharedScrubber;
     }
 
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         string value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/StringConverter.cs
+++ b/src/Verify/Serialization/Converters/StringConverter.cs
@@ -12,7 +12,7 @@ class StringConverter :
     }
 
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         string value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/StringConverter.cs
+++ b/src/Verify/Serialization/Converters/StringConverter.cs
@@ -12,10 +12,9 @@ class StringConverter :
     }
 
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         string value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         if (sharedScrubber.TryConvertString(value, out var result))
         {

--- a/src/Verify/Serialization/Converters/TextWriterConverter.cs
+++ b/src/Verify/Serialization/Converters/TextWriterConverter.cs
@@ -12,7 +12,7 @@ class TextWriterConverter :
     }
 
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         TextWriter value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/TextWriterConverter.cs
+++ b/src/Verify/Serialization/Converters/TextWriterConverter.cs
@@ -12,10 +12,9 @@ class TextWriterConverter :
     }
 
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         TextWriter value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         var stringValue = value.ToString();
         // ReSharper disable once ConditionIsAlwaysTrueOrFalse

--- a/src/Verify/Serialization/Converters/TextWriterConverter.cs
+++ b/src/Verify/Serialization/Converters/TextWriterConverter.cs
@@ -11,7 +11,7 @@ class TextWriterConverter :
         this.sharedScrubber = sharedScrubber;
     }
 
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         TextWriter value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/TimeConverter.cs
+++ b/src/Verify/Serialization/Converters/TimeConverter.cs
@@ -6,7 +6,7 @@ using VerifyTests;
 class TimeConverter :
     WriteOnlyJsonConverter<TimeOnly>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         TimeOnly value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/TimeConverter.cs
+++ b/src/Verify/Serialization/Converters/TimeConverter.cs
@@ -7,7 +7,7 @@ class TimeConverter :
     WriteOnlyJsonConverter<TimeOnly>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         TimeOnly value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/TimeConverter.cs
+++ b/src/Verify/Serialization/Converters/TimeConverter.cs
@@ -7,10 +7,9 @@ class TimeConverter :
     WriteOnlyJsonConverter<TimeOnly>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         TimeOnly value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.ToString("h:mm tt", serializer.Culture));
     }

--- a/src/Verify/Serialization/Converters/TypeJsonConverter.cs
+++ b/src/Verify/Serialization/Converters/TypeJsonConverter.cs
@@ -5,7 +5,7 @@ using VerifyTests;
 class TypeJsonConverter :
     WriteOnlyJsonConverter<Type>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         Type value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/TypeJsonConverter.cs
+++ b/src/Verify/Serialization/Converters/TypeJsonConverter.cs
@@ -6,7 +6,7 @@ class TypeJsonConverter :
     WriteOnlyJsonConverter<Type>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         Type value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/Converters/TypeJsonConverter.cs
+++ b/src/Verify/Serialization/Converters/TypeJsonConverter.cs
@@ -6,10 +6,9 @@ class TypeJsonConverter :
     WriteOnlyJsonConverter<Type>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         Type value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.SimpleName());
     }

--- a/src/Verify/Serialization/Converters/VersionConverter.cs
+++ b/src/Verify/Serialization/Converters/VersionConverter.cs
@@ -5,10 +5,9 @@ class VersionConverter :
     WriteOnlyJsonConverter<Version>
 {
     public override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         Version value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
         writer.WriteValue(value.ToString());
     }

--- a/src/Verify/Serialization/Converters/VersionConverter.cs
+++ b/src/Verify/Serialization/Converters/VersionConverter.cs
@@ -4,7 +4,7 @@ using VerifyTests;
 class VersionConverter :
     WriteOnlyJsonConverter<Version>
 {
-    public override void WriteJson(
+    public override void Write(
         VerifyJsonWriter writer,
         Version value,
         JsonSerializer serializer)

--- a/src/Verify/Serialization/Converters/VersionConverter.cs
+++ b/src/Verify/Serialization/Converters/VersionConverter.cs
@@ -5,7 +5,7 @@ class VersionConverter :
     WriteOnlyJsonConverter<Version>
 {
     public override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         Version value,
         JsonSerializer serializer)
     {

--- a/src/Verify/Serialization/JsonFormatter.cs
+++ b/src/Verify/Serialization/JsonFormatter.cs
@@ -33,12 +33,7 @@ static class JsonFormatter
         var serializer = JsonSerializer.Create(settings);
 
         var builder = new StringBuilder();
-        using var stringWriter = new StringWriter(builder)
-        {
-            NewLine = "\n"
-        };
-
-        using var writer = new VerifyJsonWriter(stringWriter, builder, verifySettings.Context);
+        using var writer = new VerifyJsonWriter(builder, verifySettings.Context);
         serializer.Serialize(writer, input);
         return builder;
     }

--- a/src/Verify/Serialization/JsonFormatter.cs
+++ b/src/Verify/Serialization/JsonFormatter.cs
@@ -38,7 +38,7 @@ static class JsonFormatter
             NewLine = "\n"
         };
 
-        using var writer = new VerifyJsonTextWriter(stringWriter, builder, verifySettings.Context);
+        using var writer = new VerifyJsonWriter(stringWriter, builder, verifySettings.Context);
         serializer.Serialize(writer, input);
         return builder;
     }

--- a/src/Verify/Serialization/JsonFormatter.cs
+++ b/src/Verify/Serialization/JsonFormatter.cs
@@ -38,7 +38,7 @@ static class JsonFormatter
             NewLine = "\n"
         };
 
-        using var writer = new JsonTextWriterEx(stringWriter, builder, verifySettings.Context);
+        using var writer = new VerifyJsonTextWriter(stringWriter, builder, verifySettings.Context);
         serializer.Serialize(writer, input);
         return builder;
     }

--- a/src/Verify/Serialization/VerifyJsonTextWriter.cs
+++ b/src/Verify/Serialization/VerifyJsonTextWriter.cs
@@ -1,14 +1,14 @@
 ﻿using System.Globalization;
 using Newtonsoft.Json;
-using VerifyTests;
+namespace VerifyTests;
 
-class JsonTextWriterEx :
+public class VerifyJsonTextWriter :
     JsonTextWriter
 {
     StringBuilder builder;
-    public Dictionary<string, object> Context { get; }
+    public IReadOnlyDictionary<string, object> Context { get; }
 
-    public JsonTextWriterEx(StringWriter writer, StringBuilder builder, Dictionary<string, object> context) :
+    public VerifyJsonTextWriter(StringWriter writer, StringBuilder builder, IReadOnlyDictionary<string, object> context) :
         base(writer)
     {
         this.builder = builder;

--- a/src/Verify/Serialization/VerifyJsonWriter.cs
+++ b/src/Verify/Serialization/VerifyJsonWriter.cs
@@ -8,8 +8,12 @@ public class VerifyJsonWriter :
     StringBuilder builder;
     public IReadOnlyDictionary<string, object> Context { get; }
 
-    public VerifyJsonWriter(StringWriter writer, StringBuilder builder, IReadOnlyDictionary<string, object> context) :
-        base(writer)
+    public VerifyJsonWriter(StringBuilder builder, IReadOnlyDictionary<string, object> context) :
+        base(
+            new StringWriter(builder)
+            {
+                NewLine = "\n"
+            })
     {
         this.builder = builder;
         Context = context;

--- a/src/Verify/Serialization/VerifyJsonWriter.cs
+++ b/src/Verify/Serialization/VerifyJsonWriter.cs
@@ -2,13 +2,13 @@
 using Newtonsoft.Json;
 namespace VerifyTests;
 
-public class VerifyJsonTextWriter :
+public class VerifyJsonWriter :
     JsonTextWriter
 {
     StringBuilder builder;
     public IReadOnlyDictionary<string, object> Context { get; }
 
-    public VerifyJsonTextWriter(StringWriter writer, StringBuilder builder, IReadOnlyDictionary<string, object> context) :
+    public VerifyJsonWriter(StringWriter writer, StringBuilder builder, IReadOnlyDictionary<string, object> context) :
         base(writer)
     {
         this.builder = builder;

--- a/src/Verify/Serialization/WriteOnlyJsonConverter.cs
+++ b/src/Verify/Serialization/WriteOnlyJsonConverter.cs
@@ -17,10 +17,10 @@ public abstract class WriteOnlyJsonConverter :
             return;
         }
 
-        WriteJson((VerifyJsonWriter)writer, value, serializer);
+        Write((VerifyJsonWriter)writer, value, serializer);
     }
 
-    public abstract void WriteJson(
+    public abstract void Write(
         VerifyJsonWriter writer,
         object value,
         JsonSerializer serializer);

--- a/src/Verify/Serialization/WriteOnlyJsonConverter.cs
+++ b/src/Verify/Serialization/WriteOnlyJsonConverter.cs
@@ -17,16 +17,13 @@ public abstract class WriteOnlyJsonConverter :
             return;
         }
 
-        var writerEx = (JsonTextWriterEx)writer;
-
-        WriteJson(writer, value, serializer, writerEx.Context);
+        WriteJson((VerifyJsonTextWriter)writer, value, serializer);
     }
 
     public abstract void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         object value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context);
+        JsonSerializer serializer);
 
     public sealed override object ReadJson(
         JsonReader reader,

--- a/src/Verify/Serialization/WriteOnlyJsonConverter.cs
+++ b/src/Verify/Serialization/WriteOnlyJsonConverter.cs
@@ -17,11 +17,11 @@ public abstract class WriteOnlyJsonConverter :
             return;
         }
 
-        WriteJson((VerifyJsonTextWriter)writer, value, serializer);
+        WriteJson((VerifyJsonWriter)writer, value, serializer);
     }
 
     public abstract void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         object value,
         JsonSerializer serializer);
 

--- a/src/Verify/Serialization/WriteOnlyJsonConverterT.cs
+++ b/src/Verify/Serialization/WriteOnlyJsonConverterT.cs
@@ -6,7 +6,7 @@ public abstract class WriteOnlyJsonConverter<T> :
     WriteOnlyJsonConverter
 {
     public sealed override void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         object value,
         JsonSerializer serializer)
     {
@@ -14,7 +14,7 @@ public abstract class WriteOnlyJsonConverter<T> :
     }
 
     public abstract void WriteJson(
-        VerifyJsonTextWriter writer,
+        VerifyJsonWriter writer,
         T value,
         JsonSerializer serializer);
 

--- a/src/Verify/Serialization/WriteOnlyJsonConverterT.cs
+++ b/src/Verify/Serialization/WriteOnlyJsonConverterT.cs
@@ -6,19 +6,17 @@ public abstract class WriteOnlyJsonConverter<T> :
     WriteOnlyJsonConverter
 {
     public sealed override void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         object value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context)
+        JsonSerializer serializer)
     {
-        WriteJson(writer, (T) value, serializer, context);
+        WriteJson(writer, (T) value, serializer);
     }
 
     public abstract void WriteJson(
-        JsonWriter writer,
+        VerifyJsonTextWriter writer,
         T value,
-        JsonSerializer serializer,
-        IReadOnlyDictionary<string, object> context);
+        JsonSerializer serializer);
 
     static Type? nullableType;
 

--- a/src/Verify/Serialization/WriteOnlyJsonConverterT.cs
+++ b/src/Verify/Serialization/WriteOnlyJsonConverterT.cs
@@ -5,15 +5,15 @@ namespace VerifyTests;
 public abstract class WriteOnlyJsonConverter<T> :
     WriteOnlyJsonConverter
 {
-    public sealed override void WriteJson(
+    public sealed override void Write(
         VerifyJsonWriter writer,
         object value,
         JsonSerializer serializer)
     {
-        WriteJson(writer, (T) value, serializer);
+        Write(writer, (T) value, serializer);
     }
 
-    public abstract void WriteJson(
+    public abstract void Write(
         VerifyJsonWriter writer,
         T value,
         JsonSerializer serializer);


### PR DESCRIPTION
## `WriteOnlyJsonConverter.WriteJson` modified

```
public abstract void WriteJson(
    JsonWriter writer,
    object value,
    JsonSerializer serializer,
    IReadOnlyDictionary<string, object> context);
```

becomes `WriteOnlyJsonConverter.Write`: 


```
public abstract void Write(
    VerifyJsonWriter writer,
    object value,
    JsonSerializer serializer);
```

## `WriteOnlyJsonConverter<T>.WriteJson` modified

```
public abstract void WriteJson(
    JsonWriter writer,
    T value,
    JsonSerializer serializer,
    IReadOnlyDictionary<string, object> context);
```

becomes `WriteOnlyJsonConverter<T>.Write` 

```
public abstract void Write(
    VerifyJsonWriter writer,
    T value,
    JsonSerializer serializer);
```

## IReadOnlyDictionary<string, object> context

The `context` paramter can now be access from `writer.Context`.