### PR TITLE
Fix UnauthorizedAccessException on Directory.CreateDirectory

### DIFF
--- a/src/Verify/Verifier/InnerVerifier.cs
+++ b/src/Verify/Verifier/InnerVerifier.cs
@@ -27,7 +27,10 @@ partial class InnerVerifier :
         else
         {
             directory = Path.Combine(sourceFileDirectory, directory);
-            Directory.CreateDirectory(directory);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
         }
 
         this.directory = directory;


### PR DESCRIPTION
In the case the directory already exists but the environment running the tests don't have the right to create new directories (A good test pipelines usually don't need those rights) then the code throw UnauthorizedAccessException.

With that code we don't try to create the directory if it already exist avoiding the UnauthorizedAccessException if the rights are missing but the directory exist.