### PR TITLE
Undo removal of 'Verifier.' in docs

### DIFF
--- a/docs/anonymous-types.md
+++ b/docs/anonymous-types.md
@@ -29,7 +29,7 @@ public Task Anon()
         FamilyName = "Aguirre"
     };
 
-    return Verify(
+    return Verifier.Verify(
         new
         {
             person1,
@@ -60,7 +60,7 @@ public async Task Anon()
         FamilyName = "Aguirre"
     };
 
-    await Verify(
+    await Verifier.Verify(
         new
         {
             person1,

--- a/docs/compared-to-assertion.md
+++ b/docs/compared-to-assertion.md
@@ -96,7 +96,7 @@ public void TraditionalTest()
 public Task SnapshotTest()
 {
     var person = ClassBeingTested.FindPerson();
-    return Verify(person);
+    return Verifier.Verify(person);
 }
 ```
 <sup><a href='/src/Verify.Xunit.Tests/Snippets/CompareToAssert.cs#L24-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-snapshottest' title='Start of snippet'>anchor</a></sup>

--- a/docs/comparer.md
+++ b/docs/comparer.md
@@ -53,13 +53,13 @@ public Task InstanceComparer()
     var settings = new VerifySettings();
     settings.UseStreamComparer(CompareImages);
     settings.UseExtension("png");
-    return VerifyFile("sample.png", settings);
+    return Verifier.VerifyFile("sample.png", settings);
 }
 
 [Fact]
 public Task InstanceComparerFluent()
 {
-    return VerifyFile("sample.png")
+    return Verifier.VerifyFile("sample.png")
         .UseStreamComparer(CompareImages)
         .UseExtension("png");
 }
@@ -76,7 +76,7 @@ public Task InstanceComparerFluent()
 VerifierSettings.RegisterStreamComparer(
     extension: "png",
     compare: CompareImages);
-await VerifyFile("TheImage.png");
+await Verifier.VerifyFile("TheImage.png");
 ```
 <sup><a href='/src/Verify.Tests/Snippets/ComparerSnippets.cs#L29-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-staticcomparer' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/converter.md
+++ b/docs/converter.md
@@ -83,7 +83,7 @@ VerifierSettings.RegisterFileConverter<Image>(
 <a id='snippet-fileconvertertypeverify'></a>
 ```cs
 using var stream = File.OpenRead("sample.tif");
-await Verify(Image.FromStream(stream));
+await Verifier.Verify(Image.FromStream(stream));
 ```
 <sup><a href='/src/Verify.Tests/Snippets/ConverterSnippets.cs#L46-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-fileconvertertypeverify' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -138,7 +138,7 @@ VerifierSettings.RegisterFileConverter(
 <!-- snippet: FileConverterExtensionVerify -->
 <a id='snippet-fileconverterextensionverify'></a>
 ```cs
-await VerifyFile("sample.tif");
+await Verifier.VerifyFile("sample.tif");
 ```
 <sup><a href='/src/Verify.Tests/Snippets/ConverterSnippets.cs#L87-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-fileconverterextensionverify' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/named-tuples.md
+++ b/docs/named-tuples.md
@@ -29,7 +29,7 @@ Can be verified:
 <!-- snippet: VerifyTuple -->
 <a id='snippet-verifytuple'></a>
 ```cs
-await VerifyTuple(() => MethodWithNamedTuple());
+await Verifier.VerifyTuple(() => MethodWithNamedTuple());
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1080-L1084' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifytuple' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -25,7 +25,7 @@ The directory that contains the test. A custom directory can be used via `UseDir
 ```cs
 var settings = new VerifySettings();
 settings.UseDirectory("CustomDirectory");
-await Verify("value", settings);
+await Verifier.Verify("value", settings);
 ```
 <sup><a href='/src/Verify.Tests/Naming/NamerTests.cs#L193-L199' title='Snippet source file'>snippet source</a> | <a href='#snippet-usedirectory' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -33,7 +33,7 @@ await Verify("value", settings);
 <!-- snippet: UseDirectoryFluent -->
 <a id='snippet-usedirectoryfluent'></a>
 ```cs
-await Verify("value")
+await Verifier.Verify("value")
     .UseDirectory("CustomDirectory");
 ```
 <sup><a href='/src/Verify.Tests/Naming/NamerTests.cs#L205-L210' title='Snippet source file'>snippet source</a> | <a href='#snippet-usedirectoryfluent' title='Start of snippet'>anchor</a></sup>
@@ -53,7 +53,7 @@ The class name that contains the test. A custom test name can be used via `UseTy
 ```cs
 var settings = new VerifySettings();
 settings.UseTypeName("CustomTypeName");
-await Verify("value", settings);
+await Verifier.Verify("value", settings);
 ```
 <sup><a href='/src/Verify.Tests/Naming/NamerTests.cs#L216-L222' title='Snippet source file'>snippet source</a> | <a href='#snippet-usetypename' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -61,7 +61,7 @@ await Verify("value", settings);
 <!-- snippet: UseTypeNameFluent -->
 <a id='snippet-usetypenamefluent'></a>
 ```cs
-await Verify("value")
+await Verifier.Verify("value")
     .UseTypeName("CustomTypeName");
 ```
 <sup><a href='/src/Verify.Tests/Naming/NamerTests.cs#L228-L233' title='Snippet source file'>snippet source</a> | <a href='#snippet-usetypenamefluent' title='Start of snippet'>anchor</a></sup>
@@ -79,7 +79,7 @@ The test method name. A custom test name can be used via `UseMethodName`:
 ```cs
 var settings = new VerifySettings();
 settings.UseMethodName("CustomMethodName");
-await Verify("value", settings);
+await Verifier.Verify("value", settings);
 ```
 <sup><a href='/src/Verify.Tests/Naming/NamerTests.cs#L239-L245' title='Snippet source file'>snippet source</a> | <a href='#snippet-usemethodname' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -89,7 +89,7 @@ Will result in `TestClass.CustomMethodName.verified.txt`.
 <!-- snippet: UseMethodNameFluent -->
 <a id='snippet-usemethodnamefluent'></a>
 ```cs
-await Verify("value")
+await Verifier.Verify("value")
     .UseMethodName("CustomMethodNameFluent");
 ```
 <sup><a href='/src/Verify.Tests/Naming/NamerTests.cs#L251-L256' title='Snippet source file'>snippet source</a> | <a href='#snippet-usemethodnamefluent' title='Start of snippet'>anchor</a></sup>
@@ -110,9 +110,9 @@ Will result in `TestClass.CustomMethodNameFluent.verified.txt`.
 public async Task MultipleCalls()
 {
     await Task.WhenAll(
-        Verify("Value1")
+        Verifier.Verify("Value1")
             .UseMethodName("MultipleCalls_1"),
-        Verify("Value1")
+        Verifier.Verify("Value1")
             .UseMethodName("MultipleCalls_2"));
 }
 ```
@@ -129,7 +129,7 @@ To fully control the `{TestClassName}.{TestMethodName}_{Parameters}` parts of th
 ```cs
 var settings = new VerifySettings();
 settings.UseFileName("CustomFileName");
-await Verify("value", settings);
+await Verifier.Verify("value", settings);
 ```
 <sup><a href='/src/Verify.Tests/Naming/NamerTests.cs#L161-L167' title='Snippet source file'>snippet source</a> | <a href='#snippet-usefilename' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -139,7 +139,7 @@ Will result in `CustomFileName.verified.txt`.
 <!-- snippet: UseFileNameFluent -->
 <a id='snippet-usefilenamefluent'></a>
 ```cs
-await Verify("value")
+await Verifier.Verify("value")
     .UseFileName("CustomFileNameFluent");
 ```
 <sup><a href='/src/Verify.Tests/Naming/NamerTests.cs#L182-L187' title='Snippet source file'>snippet source</a> | <a href='#snippet-usefilenamefluent' title='Start of snippet'>anchor</a></sup>
@@ -177,13 +177,13 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForRuntime();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Fact]
     public Task RuntimeFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForRuntime();
     }
 
@@ -192,7 +192,7 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForRuntimeAndVersion();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Fact]
@@ -200,13 +200,13 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForAssemblyConfiguration();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Fact]
     public Task AssemblyConfigurationFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForAssemblyConfiguration();
     }
 
@@ -215,13 +215,13 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForArchitecture();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Fact]
     public Task ArchitectureFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForArchitecture();
     }
 
@@ -230,13 +230,13 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForOSPlatform();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Fact]
     public Task OSPlatformFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForOSPlatform();
     }
 }
@@ -258,13 +258,13 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForRuntime();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Test]
     public Task RuntimeFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForRuntime();
     }
 
@@ -273,13 +273,13 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForAssemblyConfiguration();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Test]
     public Task AssemblyConfigurationFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForAssemblyConfiguration();
     }
 
@@ -288,13 +288,13 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForRuntimeAndVersion();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Test]
     public Task RuntimeAndVersionFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForRuntimeAndVersion();
     }
 
@@ -303,13 +303,13 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForArchitecture();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Test]
     public Task ArchitectureFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForArchitecture();
     }
 
@@ -318,13 +318,13 @@ public class UniqueForSample
     {
         var settings = new VerifySettings();
         settings.UniqueForOSPlatform();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [Test]
     public Task OSPlatformFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForOSPlatform();
     }
 }
@@ -364,13 +364,13 @@ public class UniqueForSample :
     {
         var settings = new VerifySettings();
         settings.UniqueForRuntime();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [TestMethod]
     public Task RuntimeFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForRuntime();
     }
 
@@ -379,13 +379,13 @@ public class UniqueForSample :
     {
         var settings = new VerifySettings();
         settings.UniqueForRuntimeAndVersion();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [TestMethod]
     public Task RuntimeAndVersionFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForRuntimeAndVersion();
     }
 
@@ -394,13 +394,13 @@ public class UniqueForSample :
     {
         var settings = new VerifySettings();
         settings.UniqueForAssemblyConfiguration();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [TestMethod]
     public Task AssemblyConfigurationFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForAssemblyConfiguration();
     }
 
@@ -409,13 +409,13 @@ public class UniqueForSample :
     {
         var settings = new VerifySettings();
         settings.UniqueForArchitecture();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [TestMethod]
     public Task ArchitectureFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForArchitecture();
     }
 
@@ -424,13 +424,13 @@ public class UniqueForSample :
     {
         var settings = new VerifySettings();
         settings.UniqueForOSPlatform();
-        return Verify("value", settings);
+        return Verifier.Verify("value", settings);
     }
 
     [TestMethod]
     public Task OSPlatformFluent()
     {
-        return Verify("value")
+        return Verifier.Verify("value")
             .UniqueForOSPlatform();
     }
 }
@@ -489,7 +489,7 @@ public class ExtensionSample
     {
         var settings = new VerifySettings(classLevelSettings);
         settings.UseExtension("xml");
-        return Verify(
+        return Verifier.Verify(
             target: @"
 <note>
   <to>Joe</to>
@@ -502,7 +502,7 @@ public class ExtensionSample
     [Fact]
     public Task AtMethodFluent()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
 <note>
   <to>Joe</to>
@@ -516,7 +516,7 @@ public class ExtensionSample
     [Fact]
     public Task SharedClassLevelSettings()
     {
-        return Verify(
+        return Verifier.Verify(
             target: @"
 {
   fruit: 'Apple',

--- a/docs/parameterised.md
+++ b/docs/parameterised.md
@@ -40,7 +40,7 @@ public Task InlineDataUsage(string arg)
 {
     var settings = new VerifySettings();
     settings.UseParameters(arg);
-    return Verify(arg, settings);
+    return Verifier.Verify(arg, settings);
 }
 
 [Theory]
@@ -48,7 +48,7 @@ public Task InlineDataUsage(string arg)
 [InlineData("Value2")]
 public Task InlineDataUsageFluent(string arg)
 {
-    return Verify(arg)
+    return Verifier.Verify(arg)
         .UseParameters(arg);
 }
 ```
@@ -67,14 +67,14 @@ public Task MemberDataUsage(string arg)
 {
     var settings = new VerifySettings();
     settings.UseParameters(arg);
-    return Verify(arg, settings);
+    return Verifier.Verify(arg, settings);
 }
 
 [Theory]
 [MemberData(nameof(GetData))]
 public Task MemberDataUsageFluent(string arg)
 {
-    return Verify(arg)
+    return Verifier.Verify(arg)
         .UseParameters(arg);
 }
 
@@ -111,14 +111,14 @@ public class ComplexParametersSample
     {
         var settings = new VerifySettings();
         settings.UseParameters(arg);
-        return Verify(arg, settings);
+        return Verifier.Verify(arg, settings);
     }
 
     [Theory]
     [MemberData(nameof(GetComplexMemberData))]
     public Task ComplexMemberDataFluent(ComplexData arg)
     {
-        return Verify(arg)
+        return Verifier.Verify(arg)
             .UseParameters(arg);
     }
 
@@ -128,14 +128,14 @@ public class ComplexParametersSample
     {
         var settings = new VerifySettings();
         settings.UseParameters(arg);
-        return Verify(arg, settings);
+        return Verifier.Verify(arg, settings);
     }
 
     [Theory]
     [MemberData(nameof(GetComplexMemberData))]
     public Task ComplexMemberNullableDataFluent(ComplexData? arg)
     {
-        return Verify(arg)
+        return Verifier.Verify(arg)
             .UseParameters(arg);
     }
 
@@ -162,14 +162,14 @@ public class ComplexParametersSample
     {
         var settings = new VerifySettings();
         settings.UseParameters(arg);
-        return Verify(arg, settings);
+        return Verifier.Verify(arg, settings);
     }
 
     [Theory]
     [MemberData(nameof(GetComplexMemberStructData))]
     public Task ComplexMemberStructDataFluent(ComplexStructData arg)
     {
-        return Verify(arg)
+        return Verifier.Verify(arg)
             .UseParameters(arg);
     }
 
@@ -179,14 +179,14 @@ public class ComplexParametersSample
     {
         var settings = new VerifySettings();
         settings.UseParameters(arg);
-        return Verify(arg, settings);
+        return Verifier.Verify(arg, settings);
     }
 
     [Theory]
     [MemberData(nameof(GetComplexMemberStructData))]
     public Task ComplexMemberNullableStructDataFluent(ComplexStructData? arg)
     {
-        return Verify(arg)
+        return Verifier.Verify(arg)
             .UseParameters(arg);
     }
 
@@ -231,7 +231,7 @@ public class ComplexParametersSample
 [TestCase("Value2")]
 public Task TestCaseUsage(string arg)
 {
-    return Verify(arg);
+    return Verifier.Verify(arg);
 }
 ```
 <sup><a href='/src/Verify.NUnit.Tests/Snippets/ParametersSample.cs#L25-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-nunittestcase' title='Start of snippet'>anchor</a></sup>
@@ -259,7 +259,7 @@ public class ParametersSample :
     {
         var settings = new VerifySettings();
         settings.UseParameters(arg);
-        return Verify(arg, settings);
+        return Verifier.Verify(arg, settings);
     }
 
     [DataTestMethod]
@@ -267,7 +267,7 @@ public class ParametersSample :
     [DataRow("Value2")]
     public Task DataRowUsageFluent(string arg)
     {
-        return Verify(arg)
+        return Verifier.Verify(arg)
             .UseParameters(arg);
     }
 }
@@ -294,7 +294,7 @@ public Task UseTextForParameters(string arg)
 {
     var settings = new VerifySettings();
     settings.UseTextForParameters(arg);
-    return Verify(arg, settings);
+    return Verifier.Verify(arg, settings);
 }
 
 [Theory]
@@ -302,7 +302,7 @@ public Task UseTextForParameters(string arg)
 [InlineData("Value2")]
 public Task UseTextForParametersFluent(string arg)
 {
-    return Verify(arg)
+    return Verifier.Verify(arg)
         .UseTextForParameters(arg);
 }
 ```

--- a/docs/scrubbers.md
+++ b/docs/scrubbers.md
@@ -148,7 +148,7 @@ public class ScrubbersSample
         settings.ScrubLines(removeLine: line => line.Contains("J"));
         settings.ScrubLinesContaining("b", "D");
         settings.ScrubLinesContaining(StringComparison.Ordinal, "H");
-        return Verify(
+        return Verifier.Verify(
             settings: settings,
             target: @"
                     LineA
@@ -165,7 +165,7 @@ public class ScrubbersSample
     [Fact]
     public Task LinesFluent()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
                         LineA
                         LineB
@@ -202,7 +202,7 @@ public class ScrubbersSample
         var settings = new VerifySettings();
         settings.AddScrubber(
             input => input.Replace("7D3", "TheRowVersion"));
-        return Verify(target, settings);
+        return Verifier.Verify(target, settings);
     }
 
     [Fact]
@@ -213,7 +213,7 @@ public class ScrubbersSample
             RowVersion = "7D3"
         };
 
-        return Verify(target)
+        return Verifier.Verify(target)
             .AddScrubber(
                 input => input.Replace("7D3", "TheRowVersion"));
     }
@@ -221,7 +221,7 @@ public class ScrubbersSample
     [Fact]
     public Task RemoveOrReplace()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
                         LineA
                         LineB
@@ -242,7 +242,7 @@ public class ScrubbersSample
     [Fact]
     public Task EmptyLines()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
                         LineA
                         
@@ -281,7 +281,7 @@ public class ScrubbersSample
         settings.ScrubLines(removeLine: line => line.Contains("J"));
         settings.ScrubLinesContaining("b", "D");
         settings.ScrubLinesContaining(StringComparison.Ordinal, "H");
-        return Verify(
+        return Verifier.Verify(
             settings: settings,
             target: @"
                     LineA
@@ -298,7 +298,7 @@ public class ScrubbersSample
     [Test]
     public Task LinesFluent()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
                         LineA
                         LineB
@@ -335,7 +335,7 @@ public class ScrubbersSample
         var settings = new VerifySettings();
         settings.AddScrubber(
             s => s.Replace("7D3", "TheRowVersion"));
-        return Verify(target, settings);
+        return Verifier.Verify(target, settings);
     }
 
     [Test]
@@ -346,7 +346,7 @@ public class ScrubbersSample
             RowVersion = "7D3"
         };
 
-        return Verify(target)
+        return Verifier.Verify(target)
             .AddScrubber(
                 s => s.Replace("7D3", "TheRowVersion"));
     }
@@ -354,7 +354,7 @@ public class ScrubbersSample
     [Test]
     public Task RemoveOrReplace()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
                         LineA
                         LineB
@@ -375,7 +375,7 @@ public class ScrubbersSample
     [Test]
     public Task EmptyLines()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
                         LineA
                         
@@ -415,7 +415,7 @@ public class ScrubbersSample :
         settings.ScrubLines(removeLine: line => line.Contains("J"));
         settings.ScrubLinesContaining("b", "D");
         settings.ScrubLinesContaining(StringComparison.Ordinal, "H");
-        return Verify(
+        return Verifier.Verify(
             settings: settings,
             target: @"
                     LineA
@@ -432,7 +432,7 @@ public class ScrubbersSample :
     [TestMethod]
     public Task LinesFluent()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
                         LineA
                         LineB
@@ -469,7 +469,7 @@ public class ScrubbersSample :
         var settings = new VerifySettings();
         settings.AddScrubber(
             input => input.Replace("7D3", "TheRowVersion"));
-        return Verify(target, settings);
+        return Verifier.Verify(target, settings);
     }
 
     [TestMethod]
@@ -480,7 +480,7 @@ public class ScrubbersSample :
             RowVersion = "7D3"
         };
 
-        return Verify(target)
+        return Verifier.Verify(target)
             .AddScrubber(
                 input => input.Replace("7D3", "TheRowVersion"));
     }
@@ -488,7 +488,7 @@ public class ScrubbersSample :
     [TestMethod]
     public Task RemoveOrReplace()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
                         LineA
                         LineB
@@ -509,7 +509,7 @@ public class ScrubbersSample :
     [TestMethod]
     public Task EmptyLines()
     {
-        return Verify(
+        return Verifier.Verify(
                 target: @"
                         LineA
                         
@@ -577,13 +577,13 @@ public class ScrubberLevelsSample
     {
         var settings = new VerifySettings(classLevelSettings);
         settings.AddScrubber(s => s.Replace("Two", "B"));
-        return Verify("One Two Three", settings);
+        return Verifier.Verify("One Two Three", settings);
     }
 
     [Fact]
     public Task UsageFluent()
     {
-        return Verify("One Two Three", classLevelSettings)
+        return Verifier.Verify("One Two Three", classLevelSettings)
             .AddScrubber(s => s.Replace("Two", "B"));
     }
 
@@ -619,13 +619,13 @@ public class ScrubberLevelsSample
     {
         var settings = new VerifySettings(classLevelSettings);
         settings.AddScrubber(s => s.Replace("Two", "B"));
-        return Verify("One Two Three", settings);
+        return Verifier.Verify("One Two Three", settings);
     }
 
     [Test]
     public Task SimpleFluent()
     {
-        return Verify("One Two Three", classLevelSettings)
+        return Verifier.Verify("One Two Three", classLevelSettings)
             .AddScrubber(s => s.Replace("Two", "B"));
     }
 
@@ -662,13 +662,13 @@ public class ScrubberLevelsSample :
     {
         var settings = new VerifySettings(classLevelSettings);
         settings.AddScrubber(s => s.Replace("Two", "B"));
-        return Verify("One Two Three", settings);
+        return Verifier.Verify("One Two Three", settings);
     }
 
     [TestMethod]
     public Task SimpleFluent()
     {
-        return Verify("One Two Three", classLevelSettings)
+        return Verifier.Verify("One Two Three", classLevelSettings)
             .AddScrubber(s => s.Replace("Two", "B"));
     }
 

--- a/docs/serializer-settings.md
+++ b/docs/serializer-settings.md
@@ -51,7 +51,7 @@ var target = new TheTarget
 {
     Value = "Foo"
 };
-await Verify(target);
+await Verifier.Verify(target);
 ```
 <sup><a href='/src/StrictJsonTests/Tests.cs#L42-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-usestrictjsonverify' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -118,7 +118,7 @@ public Task AddExtraSettings()
     verifySettings.ModifySerialization(settings =>
         settings.AddExtraSettings(serializerSettings =>
             serializerSettings.DefaultValueHandling = DefaultValueHandling.Include));
-    return Verify(target, verifySettings);
+    return Verifier.Verify(target, verifySettings);
 }
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L248-L262' title='Snippet source file'>snippet source</a> | <a href='#snippet-addextrasettings' title='Start of snippet'>anchor</a></sup>
@@ -135,7 +135,7 @@ public Task AddExtraSettingsFluent()
 {
     var target = new DateOnly(2000, 1, 1);
 
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(settings =>
             settings.AddExtraSettings(serializerSettings =>
                 serializerSettings.DefaultValueHandling = DefaultValueHandling.Include));
@@ -181,7 +181,7 @@ var target = new GuidTarget
     OtherGuid = Guid.NewGuid(),
 };
 
-await Verify(target);
+await Verifier.Verify(target);
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1154-L1167' title='Snippet source file'>snippet source</a> | <a href='#snippet-guid' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -221,7 +221,7 @@ To disable this behavior use:
 ```cs
 var settings = new VerifySettings();
 settings.ModifySerialization(_ => _.DontScrubGuids());
-await Verify(target, settings);
+await Verifier.Verify(target, settings);
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L420-L426' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontscrubguids' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -231,7 +231,7 @@ Or with the fluent api:
 <!-- snippet: DontScrubGuidsFluent -->
 <a id='snippet-dontscrubguidsfluent'></a>
 ```cs
-await Verify(target)
+await Verifier.Verify(target)
     .ModifySerialization(_ => _.DontScrubGuids());
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L434-L439' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontscrubguidsfluent' title='Start of snippet'>anchor</a></sup>
@@ -270,7 +270,7 @@ var target = new DateTimeTarget
     DateTimeOffsetString = dateTimeOffset.ToString("F"),
 };
 
-await Verify(target);
+await Verifier.Verify(target);
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L642-L661' title='Snippet source file'>snippet source</a> | <a href='#snippet-date' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -308,7 +308,7 @@ var target = new
 var settings = new VerifySettings();
 settings.ModifySerialization(_ => _.DontScrubDateTimes());
 
-return Verify(target, settings);
+return Verifier.Verify(target, settings);
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L893-L905' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontscrubdatetimes' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -323,7 +323,7 @@ var target = new
     Date = DateTime.Now
 };
 
-return Verify(target)
+return Verifier.Verify(target)
     .ModifySerialization(_ => _.DontScrubDateTimes());
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L910-L920' title='Snippet source file'>snippet source</a> | <a href='#snippet-dontscrubdatetimesfluent' title='Start of snippet'>anchor</a></sup>
@@ -359,7 +359,7 @@ public Task NumericIdScrubbing()
         ActualNullId = (int?) null
     };
 
-    return Verify(target);
+    return Verifier.Verify(target);
 }
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L373-L390' title='Snippet source file'>snippet source</a> | <a href='#snippet-numericid' title='Start of snippet'>anchor</a></sup>
@@ -397,7 +397,7 @@ public Task TreatAsNumericId()
     {
         TheProperty = 5
     };
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(
             settings => settings.TreatAsNumericId(
                 member => member.Name == "TheProperty"));
@@ -437,7 +437,7 @@ public Task NumericIdScrubbingDisabled()
         PossibleNullId = (int?) 5,
         ActualNullId = (int?) null
     };
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(_ => _.DontScrubNumericIds());
 }
 ```
@@ -486,12 +486,12 @@ settings.ModifySerialization(_ =>
     _.DontScrubDateTimes();
     _.DontIgnoreFalse();
 });
-await Verify(target, settings);
+await Verifier.Verify(target, settings);
 ```
 <sup><a href='/src/Verify.MSTest.Tests/VerifyObjectSamples.cs#L13-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-changedefaultsperverification' title='Start of snippet'>anchor</a></sup>
 <a id='snippet-changedefaultsperverification-1'></a>
 ```cs
-await Verify(target)
+await Verifier.Verify(target)
     .ModifySerialization(_ =>
     {
         _.DontIgnoreEmptyCollections();
@@ -503,7 +503,7 @@ await Verify(target)
 <sup><a href='/src/Verify.MSTest.Tests/VerifyObjectSamples.cs#L28-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-changedefaultsperverification-1' title='Start of snippet'>anchor</a></sup>
 <a id='snippet-changedefaultsperverification-2'></a>
 ```cs
-await Verify(target)
+await Verifier.Verify(target)
     .ModifySerialization(_ =>
     {
         _.DontIgnoreEmptyCollections();
@@ -607,7 +607,7 @@ public Task ScopedSerializer()
     };
     var settings = new VerifySettings();
     settings.AddExtraSettings(_ => _.TypeNameHandling = TypeNameHandling.All);
-    return Verify(person, settings);
+    return Verifier.Verify(person, settings);
 }
 
 [Fact]
@@ -618,7 +618,7 @@ public Task ScopedSerializerFluent()
         GivenNames = "John",
         FamilyName = "Smith"
     };
-    return Verify(person)
+    return Verifier.Verify(person)
         .AddExtraSettings(_ => _.TypeNameHandling = TypeNameHandling.All);
 }
 ```
@@ -679,7 +679,7 @@ public Task IgnoreType()
         _.IgnoreMembersWithType<ToIgnore>();
         _.IgnoreMembersWithType<ToIgnoreStruct>();
     });
-    return Verify(target, settings);
+    return Verifier.Verify(target, settings);
 }
 
 [Fact]
@@ -708,7 +708,7 @@ public Task IgnoreTypeFluent()
         ToIncludeStruct = new ("Value"),
         ToIncludeStructNullable = new ("Value"),
     };
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(_ =>
         {
             _.IgnoreMembersWithType<ToIgnore>();
@@ -778,7 +778,7 @@ public Task AddIgnoreInstance()
     var settings = new VerifySettings();
     settings.ModifySerialization(
         _ => _.IgnoreInstance<Instance>(x => x.Property == "Ignore"));
-    return Verify(target, settings);
+    return Verifier.Verify(target, settings);
 }
 
 [Fact]
@@ -795,7 +795,7 @@ public Task AddIgnoreInstanceFluent()
             Property = "Include"
         }
     };
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(
             _ => { _.IgnoreInstance<Instance>(x => x.Property == "Ignore"); });
 }
@@ -852,7 +852,7 @@ public Task WithObsoleteProp()
         ObsoleteProperty = "value1",
         OtherProperty = "value2"
     };
-    return Verify(target);
+    return Verifier.Verify(target);
 }
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L2129-L2150' title='Snippet source file'>snippet source</a> | <a href='#snippet-withobsoleteprop' title='Start of snippet'>anchor</a></sup>
@@ -888,7 +888,7 @@ public Task WithObsoletePropIncluded()
     };
     var settings = new VerifySettings();
     settings.ModifySerialization(_ => _.IncludeObsoletes());
-    return Verify(target, settings);
+    return Verifier.Verify(target, settings);
 }
 
 [Fact]
@@ -899,7 +899,7 @@ public Task WithObsoletePropIncludedFluent()
         ObsoleteProperty = "value1",
         OtherProperty = "value2"
     };
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(_ => _.IncludeObsoletes());
 }
 ```
@@ -956,7 +956,7 @@ public Task IgnoreMemberByExpression()
         _.IgnoreMember<IgnoreExplicitTarget>(x => x.GetOnlyProperty);
         _.IgnoreMember<IgnoreExplicitTarget>(x => x.PropertyThatThrows);
     });
-    return Verify(target, settings);
+    return Verifier.Verify(target, settings);
 }
 
 [Fact]
@@ -968,7 +968,7 @@ public Task IgnoreMemberByExpressionFluent()
         Field = "Value",
         Property = "Value"
     };
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(_ =>
         {
             _.IgnoreMember<IgnoreExplicitTarget>(x => x.Property);
@@ -1043,7 +1043,7 @@ public Task IgnoreMemberByName()
         // For a specific type with expression
         _.IgnoreMember<IgnoreExplicitTarget>(_ => _.PropertyThatThrows);
     });
-    return Verify(target, settings);
+    return Verifier.Verify(target, settings);
 }
 
 [Fact]
@@ -1056,7 +1056,7 @@ public Task IgnoreMemberByNameFluent()
         Property = "Value",
         PropertyByName = "Value"
     };
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(_ =>
         {
             // For all types
@@ -1132,14 +1132,14 @@ public Task CustomExceptionProp()
     var target = new WithCustomException();
     var settings = new VerifySettings();
     settings.ModifySerialization(_ => _.IgnoreMembersThatThrow<CustomException>());
-    return Verify(target, settings);
+    return Verifier.Verify(target, settings);
 }
 
 [Fact]
 public Task CustomExceptionPropFluent()
 {
     var target = new WithCustomException();
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(_ => _.IgnoreMembersThatThrow<CustomException>());
 }
 ```
@@ -1179,7 +1179,7 @@ public Task ExceptionMessageProp()
     var settings = new VerifySettings();
     settings.ModifySerialization(
         _ => _.IgnoreMembersThatThrow<Exception>(x => x.Message == "Ignore"));
-    return Verify(target, settings);
+    return Verifier.Verify(target, settings);
 }
 
 [Fact]
@@ -1187,7 +1187,7 @@ public Task ExceptionMessagePropFluent()
 {
     var target = new WithExceptionIgnoreMessage();
 
-    return Verify(target)
+    return Verifier.Verify(target)
         .ModifySerialization(
             _ => _.IgnoreMembersThatThrow<Exception>(x => x.Message == "Ignore"));
 }
@@ -1338,7 +1338,7 @@ public Task MemberConverterByExpression()
         expression: x => x.Property,
         converter: (target, member) => $"{target}_{member}_Suffix");
 
-    return Verify(input);
+    return Verifier.Verify(input);
 }
 ```
 <sup><a href='/src/Verify.Tests/Serialization/SerializationTests.cs#L1748-L1772' title='Snippet source file'>snippet source</a> | <a href='#snippet-memberconverter' title='Start of snippet'>anchor</a></sup>
@@ -1396,7 +1396,7 @@ When when content is verified:
 [Fact]
 public Task WithJsonAppender()
 {
-    return Verify("TheValue");
+    return Verifier.Verify("TheValue");
 }
 ```
 <sup><a href='/src/Verify.Tests/Converters/JsonAppenderTests.cs#L39-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-jsonappender' title='Start of snippet'>anchor</a></sup>
@@ -1423,7 +1423,7 @@ If the target is a stream or binary file:
 [Fact]
 public Task Stream()
 {
-    return Verify(FileHelpers.OpenRead("sample.txt"));
+    return Verifier.Verify(FileHelpers.OpenRead("sample.txt"));
 }
 ```
 <sup><a href='/src/Verify.Tests/Converters/JsonAppenderTests.cs#L72-L78' title='Snippet source file'>snippet source</a> | <a href='#snippet-jsonappenderstream' title='Start of snippet'>anchor</a></sup>

--- a/docs/verify-options.md
+++ b/docs/verify-options.md
@@ -56,7 +56,7 @@ public Task OnHandlersSample()
             Debug.WriteLine(message);
             return Task.CompletedTask;
         });
-    return Verify("value");
+    return Verifier.Verify("value");
 }
 ```
 <sup><a href='/src/Verify.Tests/Snippets/Snippets.cs#L7-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-onhandlers' title='Start of snippet'>anchor</a></sup>

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ public class Sample
     public Task Test()
     {
         var person = ClassBeingTested.FindPerson();
-        return Verify(person);
+        return Verifier.Verify(person);
     }
 }
 ```
@@ -122,7 +122,7 @@ public class Sample
     public Task Test()
     {
         var person = ClassBeingTested.FindPerson();
-        return Verify(person);
+        return Verifier.Verify(person);
     }
 }
 ```
@@ -179,7 +179,7 @@ public class Sample :
     public Task Test()
     {
         var person = ClassBeingTested.FindPerson();
-        return Verify(person);
+        return Verifier.Verify(person);
     }
 }
 ```
@@ -348,7 +348,7 @@ public class StaticSettings
     [Fact]
     public Task Test()
     {
-        return Verify("String to verify");
+        return Verifier.Verify("String to verify");
     }
 }
 


### PR DESCRIPTION
Hey, looks like find replace in 41e5e4f086fe668e9b480a2ca553cfb9af02abc1 broke the example docs.