### PR TITLE
Add devops instructions to build-server.source.md

### DIFF
--- a/docs/mdsource/build-server.source.md
+++ b/docs/mdsource/build-server.source.md
@@ -27,6 +27,44 @@ Use a [if: failure()](https://docs.github.com/en/free-pro-team@latest/actions/re
       **/*.received.*
 ```
 
+### Azure DevOps YAML Pipeline
+Directly after the test runner step add a build step to set a flag if the testrunner failed.  This is done by using a [failed condition](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml).  This flag will be evaluated in the CopyFiles and 
+PublishBuildArtifacts steps below.
+
+```yaml
+- task: CmdLine@2
+  displayName: 'Set flag to publish received files when previous step fails'
+  condition: failed()
+  inputs:
+    script: 'echo ##vso[task.setvariable variable=publishverify]Yes'
+```
+
+Since the PublishBuildArtifacts step in DevOps does not allow a wildcard we need stage the 'received' files before publishing them:
+
+```yaml
+- task: CopyFiles@2
+  condition: eq(variables['publishverify'], 'Yes')
+  displayName: 'Copy received files to Artifact Staging'
+  inputs:
+    contents: '**\*.received.*' 
+    targetFolder: '$(Build.ArtifactStagingDirectory)\Verify'
+    cleanTargetFolder: true
+    overWrite: true
+```
+Finally publish the staged files as a build artifact:
+
+```yaml
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish received files as Artifacts'
+  name: 'verifypublish'
+  condition: eq(variables['publishverify'], 'Yes')
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\Verify'
+    ArtifactName: 'Verify'
+    publishLocation: 'Container'
+``` 
+
+
 
 ## Custom directory and file name
 


### PR DESCRIPTION
Added instruction of how to gather received files as a build artifact when using an Azure Devops pipeline