### PR TITLE
Use CustomValueProvider for ShouldSerialize checks

### DIFF
--- a/src/Verify.Tests/Serialization/SerializationTests.cs
+++ b/src/Verify.Tests/Serialization/SerializationTests.cs
@@ -1941,11 +1941,11 @@ public class SerializationTests
 
     class WithCustomException
     {
-        public Guid CustomExceptionProperty => throw new CustomException();
+        public Guid CustomExceptionGuid => throw new CustomException();
 
-        public IEnumerable<int> CustomExceptionProperty2 => throw new CustomException();
+        public int[] CustomExceptionArray => throw new CustomException();
 
-        public int[] CustomExceptionProperty3 => throw new CustomException();
+        public List<string> CustomExceptionList => throw new CustomException();
     }
 
     [Fact]

--- a/src/Verify.Tests/Serialization/SerializationTests.cs
+++ b/src/Verify.Tests/Serialization/SerializationTests.cs
@@ -1942,6 +1942,10 @@ public class SerializationTests
     class WithCustomException
     {
         public Guid CustomExceptionProperty => throw new CustomException();
+
+        public IEnumerable<int> CustomExceptionProperty2 => throw new CustomException();
+
+        public int[] CustomExceptionProperty3 => throw new CustomException();
     }
 
     [Fact]

--- a/src/Verify/Serialization/CustomContractResolver.cs
+++ b/src/Verify/Serialization/CustomContractResolver.cs
@@ -127,12 +127,11 @@
             return property;
         }
 
-        if (settings.TryGetShouldSerialize(memberType, valueProvider.GetValue, out var shouldSerialize))
+        property.ValueProvider = new CustomValueProvider(valueProvider, memberType, settings.ignoreMembersThatThrow, VerifierSettings.GetMemberConverter(member));
+        if (settings.TryGetShouldSerialize(memberType, property.ValueProvider.GetValue, out var shouldSerialize))
         {
             property.ShouldSerialize = shouldSerialize;
         }
-
-        property.ValueProvider = new CustomValueProvider(valueProvider, memberType, settings.ignoreMembersThatThrow, VerifierSettings.GetMemberConverter(member));
 
         return property;
     }


### PR DESCRIPTION
By using valueProvider.GetValue directly we can encounter members that throw exceptions which were explicitly ignored by the user. Therefore we need to use the CustomValueProvider in order to handle such ignored exceptions.