### PR TITLE
Fix #564 - Handle empty user profile

### DIFF
--- a/src/Verify/Serialization/Scrubbers/ApplyScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/ApplyScrubbers.cs
@@ -49,9 +49,11 @@ static class ApplyScrubbers
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             var profileDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var altProfileDir = profileDir.ReplaceAltDirChar();
-            replacements[profileDir] = "{UserProfile}";
-            replacements[altProfileDir] = "{UserProfile}";
+            if (!string.IsNullOrWhiteSpace(profileDir)) {
+                var altProfileDir = profileDir.ReplaceAltDirChar();
+                replacements[profileDir] = "{UserProfile}";
+                replacements[altProfileDir] = "{UserProfile}";
+            }
         }
 
         AddProjectAndSolutionReplacements(solutionDir, projectDir, replacements);


### PR DESCRIPTION
Skip the replacements for the user profile in case the special folder is not set.