### PR TITLE
Add mapping from win build paths to WSL paths

### DIFF
--- a/src/Verify.Xunit/Verifier.cs
+++ b/src/Verify.Xunit/Verifier.cs
@@ -37,7 +37,7 @@ public static partial class Verifier
         [CallerFilePath] string sourceFile = "") =>
         Verify(
             settings,
-            sourceFile,
+            IoHelpers.GetMappedBuildPath(sourceFile),
             _ => _.Verify(target, rawTargets));
 
     public static SettingsTask Verify(
@@ -46,7 +46,7 @@ public static partial class Verifier
         [CallerFilePath] string sourceFile = "") =>
         Verify(
             settings,
-            sourceFile,
+            IoHelpers.GetMappedBuildPath(sourceFile),
             _ => _.Verify(targets));
 
     static SettingsTask Verify(

--- a/src/Verify.Xunit/Verifier_Directory.cs
+++ b/src/Verify.Xunit/Verifier_Directory.cs
@@ -16,7 +16,7 @@ public static partial class Verifier
         object? info = null,
         FileScrubber? fileScrubber = null,
         [CallerFilePath] string sourceFile = "") =>
-        Verify(settings, sourceFile, _ => _.VerifyDirectory(path, include, pattern, options, info, fileScrubber), true);
+        Verify(settings, IoHelpers.GetMappedBuildPath(sourceFile), _ => _.VerifyDirectory(path, include, pattern, options, info, fileScrubber), true);
 
     /// <summary>
     /// Verifies the contents of <param name="path"/>.

--- a/src/Verify/DerivePaths/AttributeReader.cs
+++ b/src/Verify/DerivePaths/AttributeReader.cs
@@ -18,37 +18,41 @@ public static class AttributeReader
         GetProjectDirectory(Assembly.GetCallingAssembly());
 
     public static string GetProjectDirectory(Assembly assembly) =>
-        GetValue(assembly, "Verify.ProjectDirectory");
+        GetValue(assembly, "Verify.ProjectDirectory", true);
 
     public static bool TryGetProjectDirectory([NotNullWhen(true)] out string? projectDirectory) =>
         TryGetProjectDirectory(Assembly.GetCallingAssembly(), out projectDirectory);
 
     public static bool TryGetProjectDirectory(Assembly assembly, [NotNullWhen(true)] out string? projectDirectory) =>
-        TryGetValue(assembly, "Verify.ProjectDirectory", out projectDirectory);
+        TryGetValue(assembly, "Verify.ProjectDirectory", out projectDirectory, true);
 
     public static string GetSolutionDirectory() =>
         GetSolutionDirectory(Assembly.GetCallingAssembly());
 
     public static string GetSolutionDirectory(Assembly assembly) =>
-        GetValue(assembly, "Verify.SolutionDirectory");
+        GetValue(assembly, "Verify.SolutionDirectory", true);
 
     public static bool TryGetSolutionDirectory([NotNullWhen(true)] out string? solutionDirectory) =>
         TryGetSolutionDirectory(Assembly.GetCallingAssembly(), out solutionDirectory);
 
     public static bool TryGetSolutionDirectory(Assembly assembly, [NotNullWhen(true)] out string? solutionDirectory) =>
-        TryGetValue(assembly, "Verify.SolutionDirectory", out solutionDirectory);
+        TryGetValue(assembly, "Verify.SolutionDirectory", out solutionDirectory, true);
 
-    static bool TryGetValue(Assembly assembly, string key, [NotNullWhen(true)] out string? value)
+    static bool TryGetValue(Assembly assembly, string key, [NotNullWhen(true)] out string? value, bool isSourcePath = false)
     {
         value = assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
             .SingleOrDefault(_ => _.Key == key)
             ?.Value;
+        if (isSourcePath)
+        {
+            value = value == null ? null : IoHelpers.GetMappedBuildPath(value);
+        }
         return value is not null;
     }
 
-    static string GetValue(Assembly assembly, string key)
+    static string GetValue(Assembly assembly, string key, bool isSourcePath = false)
     {
-        if (TryGetValue(assembly, key, out var value))
+        if (TryGetValue(assembly, key, out var value, isSourcePath))
         {
             return value;
         }

--- a/src/Verify/IoHelpers.cs
+++ b/src/Verify/IoHelpers.cs
@@ -161,6 +161,58 @@
 
     }
 
+    static bool? AppearsToBeWslRun;
+
+    public static string GetMappedBuildPath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        AppearsToBeWslRun ??= !path.Contains(Path.DirectorySeparatorChar) && path.Contains("\\");
+
+        if (!AppearsToBeWslRun.Value)
+        {
+            return path;
+        }
+
+        string currentDir = Environment.CurrentDirectory;
+        const string wslMountDir = "/mnt/";
+        if (!currentDir.StartsWith(wslMountDir, StringComparison.CurrentCultureIgnoreCase))
+        {
+            AppearsToBeWslRun = false;
+            return path;
+        }
+
+        currentDir = currentDir.Substring(wslMountDir.Length);
+
+        string currentVolume = currentDir.Substring(0, currentDir.IndexOf(Path.DirectorySeparatorChar));
+        if (!path.StartsWith(currentVolume, StringComparison.CurrentCultureIgnoreCase) || path.Length < 3)
+        {
+            return path;
+        }
+
+        // Path.GetPathRoot(path) cannot be used - due to having different platform rules
+        string buildVolume = path.Substring(0, 3);
+        if (!(buildVolume[1] == ':' && buildVolume[2] == '\\'))
+        {
+            return path;
+        }
+
+        string mappedPath =
+            wslMountDir +
+            currentVolume +
+            Path.DirectorySeparatorChar +
+            path.Substring(buildVolume.Length).Replace('\\', Path.DirectorySeparatorChar);
+        if (!File.Exists(mappedPath) && !Directory.Exists(mappedPath))
+        {
+            return path;
+        }
+
+        return mappedPath;
+    }
+
 #if NET5_0_OR_GREATER || NETCOREAPP3_0_OR_GREATER
 
     public static async Task<StringBuilder> ReadStringBuilderWithFixedLines(string path)


### PR DESCRIPTION
## Problem

Running under WSL crashes due to mixing windows and subsystem mapped files
https://github.com/VerifyTests/Verify/issues/654

## Proposed solution

Added prototype mapper function mapping the build time paths to mapped WSL paths.
Utility would need to be called everywhere where build time paths are being used (so `AttributeReader` and all methods using `CallerFilePathAttribute`)

## What is missing

Adding `IoHelpers.GetMappedBuildPath` to all methods using `CallerFilePathAttribute`, only few sample usages were treated (so that debugging of `WithDirectory` test could be performed)