### PR TITLE
Make snapshot and target files enumeration equivalent

### DIFF
--- a/src/Verify/Verifier/InnerVerifier_Directory.cs
+++ b/src/Verify/Verifier/InnerVerifier_Directory.cs
@@ -15,7 +15,8 @@
         pattern ??= "*";
         option ??= new()
         {
-            RecurseSubdirectories = true
+            RecurseSubdirectories = true,
+            AttributesToSkip = 0
         };
         var targets = await ToTargets(
                 path,


### PR DESCRIPTION
## Problem

Support for dot filenames
https://github.com/VerifyTests/Verify/issues/699

## Solution

Make the target files enumeration in `InnerVerifier_Directory.VerifyDirectory` equivalent to snapshot files enumeration in `InnerVerifier.InitForDirectoryConvention`