### PR TITLE
Make sure that Hidden files are included in the EnumeratedFiles

### DIFF
--- a/src/Verify.Xunit.Tests/Tests.cs
+++ b/src/Verify.Xunit.Tests/Tests.cs
@@ -84,13 +84,7 @@ public class Tests
 
     [Fact]
     public Task WithDirectory() =>
-        VerifyDirectory(
-            directoryToVerify,
-            options: new()
-            {
-                RecurseSubdirectories = true,
-                AttributesToSkip = FileAttributes.System
-            });
+        VerifyDirectory(directoryToVerify);
 
     #endregion
 
@@ -100,11 +94,6 @@ public class Tests
     public Task VerifyDirectoryWithInfo() =>
         VerifyDirectory(
             directoryToVerify,
-            options: new()
-            {
-                RecurseSubdirectories = true,
-                AttributesToSkip = FileAttributes.System
-            },
             info: "the info");
 
     #endregion
@@ -115,11 +104,6 @@ public class Tests
     public Task VerifyDirectoryWithFileScrubber() =>
         VerifyDirectory(
             directoryToVerify,
-            options: new()
-            {
-                RecurseSubdirectories = true,
-                AttributesToSkip = FileAttributes.System
-            },
             fileScrubber: (path, builder) =>
             {
                 if (Path.GetFileName(path) == "TextDoc.txt")

--- a/src/Verify.Xunit.Tests/Tests.cs
+++ b/src/Verify.Xunit.Tests/Tests.cs
@@ -84,7 +84,13 @@ public class Tests
 
     [Fact]
     public Task WithDirectory() =>
-        VerifyDirectory(directoryToVerify);
+        VerifyDirectory(
+            directoryToVerify,
+            options: new()
+            {
+                RecurseSubdirectories = true,
+                AttributesToSkip = FileAttributes.System
+            });
 
     #endregion
 
@@ -94,6 +100,11 @@ public class Tests
     public Task VerifyDirectoryWithInfo() =>
         VerifyDirectory(
             directoryToVerify,
+            options: new()
+            {
+                RecurseSubdirectories = true,
+                AttributesToSkip = FileAttributes.System
+            },
             info: "the info");
 
     #endregion
@@ -104,6 +115,11 @@ public class Tests
     public Task VerifyDirectoryWithFileScrubber() =>
         VerifyDirectory(
             directoryToVerify,
+            options: new()
+            {
+                RecurseSubdirectories = true,
+                AttributesToSkip = FileAttributes.System
+            },
             fileScrubber: (path, builder) =>
             {
                 if (Path.GetFileName(path) == "TextDoc.txt")

--- a/src/Verify/Verifier/InnerVerifier_Directory.cs
+++ b/src/Verify/Verifier/InnerVerifier_Directory.cs
@@ -15,7 +15,8 @@
         pattern ??= "*";
         option ??= new()
         {
-            RecurseSubdirectories = true
+            RecurseSubdirectories = true,
+            AttributesToSkip = FileAttributes.System
         };
         var targets = await ToTargets(
                 path,


### PR DESCRIPTION
This aims to solve the failing tests running on macOS with the tests being:

- `Tests.WithDirectory`
- `Tests.VerifyDirectoryWithInfo`
- `Tests.VerifyDirectoryWithFileScrubber`