### PR TITLE
obsolete Counter Id replacement logic

### DIFF
--- a/src/Verify/Counter_Object.cs
+++ b/src/Verify/Counter_Object.cs
@@ -2,15 +2,21 @@
 
 public partial class Counter
 {
+    [Obsolete("Id replacement no longer used")]
     ConcurrentDictionary<object, (int intValue, string stringValue)> idCache = new();
+
+    [Obsolete("Id replacement no longer used")]
     int currentId;
 
+    [Obsolete("Id replacement no longer used")]
     public int NextId(object input) =>
         NextValue(input).intValue;
 
+    [Obsolete("Id replacement no longer used")]
     public string NextIdString(object input) =>
         NextValue(input).stringValue;
 
+    [Obsolete("Id replacement no longer used")]
     (int intValue, string stringValue) NextValue(object input) =>
         idCache.GetOrAdd(input, _ =>
         {


### PR DESCRIPTION
Id replacement has already been removed in a previous major, so no reason to keep the Id counting logic