### PR TITLE
fix broken ScrubMember

### DIFF
--- a/src/Verify/Serialization/VerifierSettings_SerializationMaps.cs
+++ b/src/Verify/Serialization/VerifierSettings_SerializationMaps.cs
@@ -46,7 +46,7 @@ public static partial class VerifierSettings
 
     public static void ScrubMember<T>(Expression<Func<T, object?>> expression)
         where T : notnull =>
-        serialization.IgnoreMembers(expression);
+        serialization.ScrubMember(expression);
 
     public static void IgnoreMembers<T>(params string[] names)
         where T : notnull =>


### PR DESCRIPTION
`public static void ScrubMember<T>(Expression<Func<T, object?>> expression)` was pointing to `IgnoreMember`