### PR TITLE
Fix VirtualizedRunHelper StackOverflow

### DIFF
--- a/src/Verify/DerivePaths/AttributeReader.cs
+++ b/src/Verify/DerivePaths/AttributeReader.cs
@@ -21,10 +21,10 @@ public static class AttributeReader
         GetValue(assembly, "Verify.ProjectDirectory", true);
 
     public static bool TryGetProjectDirectory([NotNullWhen(true)] out string? projectDirectory) =>
-        TryGetProjectDirectory(Assembly.GetCallingAssembly(), out projectDirectory);
+        TryGetProjectDirectory(Assembly.GetCallingAssembly(), true, out projectDirectory);
 
     public static bool TryGetProjectDirectory(Assembly assembly, [NotNullWhen(true)] out string? projectDirectory) =>
-        TryGetValue(assembly, "Verify.ProjectDirectory", out projectDirectory, true);
+        TryGetProjectDirectory(assembly, true, out projectDirectory);
 
     public static string GetSolutionDirectory() =>
         GetSolutionDirectory(Assembly.GetCallingAssembly());
@@ -43,6 +43,9 @@ public static class AttributeReader
 
     internal static bool TryGetSolutionDirectory(Assembly assembly, bool mapPathForVirtualizedRun, [NotNullWhen(true)] out string? solutionDirectory) =>
         TryGetValue(assembly, "Verify.SolutionDirectory", out solutionDirectory, mapPathForVirtualizedRun);
+
+    internal static bool TryGetProjectDirectory(Assembly assembly, bool mapPathForVirtualizedRun, [NotNullWhen(true)] out string? projectDirectory) =>
+        TryGetValue(assembly, "Verify.ProjectDirectory", out projectDirectory, mapPathForVirtualizedRun);
 
     static bool TryGetValue(Assembly assembly, string key, [NotNullWhen(true)] out string? value, bool isSourcePath = false)
     {

--- a/src/Verify/VirtualizedRunHelper.cs
+++ b/src/Verify/VirtualizedRunHelper.cs
@@ -13,10 +13,9 @@ class VirtualizedRunHelper
 
     public VirtualizedRunHelper(Assembly userAssembly)
     {
-        var originalCodeBaseRoot = AttributeReader.TryGetSolutionDirectory(userAssembly, false, out var solutionDir)
-            ? solutionDir
-            : AttributeReader.GetProjectDirectory(userAssembly);
         var appearsBuiltOnDifferentPlatform =
+            (AttributeReader.TryGetSolutionDirectory(userAssembly, false, out var originalCodeBaseRoot) ||
+             AttributeReader.TryGetProjectDirectory(userAssembly, false, out originalCodeBaseRoot)) &&
             !string.IsNullOrEmpty(originalCodeBaseRoot) &&
             !originalCodeBaseRoot.Contains(Path.DirectorySeparatorChar) &&
             originalCodeBaseRoot.Contains("\\");
@@ -38,7 +37,7 @@ class VirtualizedRunHelper
         }
 
         //remove the drive info from the code root
-        var mappedCodeBaseRootRelative = originalCodeBaseRoot.Replace('\\', '/');
+        var mappedCodeBaseRootRelative = originalCodeBaseRoot!.Replace('\\', '/');
         if (!TryRemoveDirFromStartOfPath(ref mappedCodeBaseRootRelative))
         {
             return;


### PR DESCRIPTION
Fixes #774

### Background
`VirtualizedRunHelper` need information about codebase root - sourcing this from `AttributeReader` to obtain solution or project dir.
`AttributeReader` is returning build time specific paths, so for virtualized runs those might need to be remmaped - `VirtualizedRunHelper` is used for that.
==> we have recipe for infinite recursion. So `VirtualizedRunHelper` was indicating to `AttributeReader` via boolean flag if the remapping is requested. The flag was applied only to obtaining solution dir, if that failed and code falled back to obtaining project dir - infiite recursion happened.

### Solution
Proper applying of no-path-remmaping flag to all calls to `AttributeReader` from `VirtualizedRunHelper`
