### PR TITLE
Fix VerifierSettings.InitializePlugins() fails when assembly name contains a dot

### DIFF
--- a/src/Verify.Tests/PluginConventionTests.cs
+++ b/src/Verify.Tests/PluginConventionTests.cs
@@ -1,4 +1,4 @@
-﻿
+
 #pragma warning disable CS0618
 public class PluginConventionTests
 {
@@ -16,6 +16,12 @@ public class PluginConventionTests
         Assert.True(VerifierSettings.TryGetType(typeof(VerifySamplePlugin).Assembly.Location, out var type));
         Assert.Same(typeof(VerifySamplePlugin), type);
     }
+
+    [Theory]
+    [InlineData("VerifySamplePlugin", "VerifyTests.VerifySamplePlugin")]
+    [InlineData("Verify.ICSharpCode.Decompiler", "VerifyTests.VerifyICSharpCodeDecompiler")]
+    public void GetTypeName(string assemblyName, string expectedTypeName) =>
+        Assert.Equal(expectedTypeName, VerifierSettings.GetTypeName(assemblyName));
 
     [Fact]
     public void InvokeInitialize()

--- a/src/Verify/VerifierSettings_PluginConvention.cs
+++ b/src/Verify/VerifierSettings_PluginConvention.cs
@@ -38,19 +38,22 @@ public static partial class VerifierSettings
 
     internal static bool TryGetType(string file, [NotNullWhen(true)] out Type? type)
     {
-        var name = Path.GetFileNameWithoutExtension(file);
-        if (!name.StartsWith("Verify."))
+        var assemblyName = Path.GetFileNameWithoutExtension(file);
+        if (!assemblyName.StartsWith("Verify."))
         {
             type = null;
             return false;
         }
 #pragma warning disable CS0618
-        var assembly = Assembly.LoadWithPartialName(name)!;
+        var assembly = Assembly.LoadWithPartialName(assemblyName)!;
 #pragma warning restore CS0618
-        var typeName = $"VerifyTests.{name.Replace(".", "")}";
+        var typeName = GetTypeName(assemblyName);
         type = assembly.GetType(typeName);
         return type != null;
     }
+
+    internal static string GetTypeName(string assemblyName) =>
+        $"VerifyTests.{assemblyName.Replace(".", "")}";
 
     internal static void InvokeInitialize(Type type)
     {

--- a/src/Verify/VerifierSettings_PluginConvention.cs
+++ b/src/Verify/VerifierSettings_PluginConvention.cs
@@ -1,4 +1,4 @@
-﻿namespace VerifyTests;
+namespace VerifyTests;
 
 public static partial class VerifierSettings
 {
@@ -47,7 +47,7 @@ public static partial class VerifierSettings
 #pragma warning disable CS0618
         var assembly = Assembly.LoadWithPartialName(name)!;
 #pragma warning restore CS0618
-        var typeName = name.Replace("Verify.", "VerifyTests.Verify");
+        var typeName = $"VerifyTests.{name.Replace(".", "")}";
         type = assembly.GetType(typeName);
         return type != null;
     }


### PR DESCRIPTION
Fix #865: Type-names must not contain dots.