### PR TITLE
Document workaround for serializing F# lists of DUs

### DIFF
--- a/docs/mdsource/fsharp.source.md
+++ b/docs/mdsource/fsharp.source.md
@@ -8,6 +8,13 @@ To serialize F# types properly, add the converters:
 VerifierSettings.AddExtraSettings(fun settings -> settings.AddFSharpConverters())
 ```
 
+Note: the `DiscriminatedUnionConverter` converter is currently added last in the internal list, and this can cause errors when trying to serialize a list of DU.  
+To work around the problem, you can add the `DiscriminatedUnionConverter` again just before adding the other converters, like so:
+```fs
+VerifierSettings.AddExtraSettings(fun settings ->
+    settings.Converters.Add(Argon.DiscriminatedUnionConverter())
+    Argon.FSharpConverters.AddFSharpConverters(settings))
+```
 
 ## NullValueHandling
 


### PR DESCRIPTION
Hello,

This is unfortunate, but it looks like the order json converters are added matters, and the F# discriminated unions converter is added last, so trying to serialize a list of DU types fails with an error similar to this:
```
Argon.JsonWriterException : Unsupported type: REDACTED.Business+CommandWithProgress. Use the JsonSerializer class to get the object's JSON representation. Path ''.
```

Manually adding the `DiscriminatedUnionConverter` in the extra converters just before the other F# converters fixes the issue.