### PR TITLE
XML docs: param → paramref where appropriate

### DIFF
--- a/src/Verify.Expecto/Verifier_Directory.cs
+++ b/src/Verify.Expecto/Verifier_Directory.cs
@@ -7,7 +7,7 @@ public static partial class Verifier
 #if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public static Task<VerifyResult> VerifyDirectory(
         string name,
@@ -25,7 +25,7 @@ public static partial class Verifier
     }
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object target)</code> which will verify the full path.
     /// </summary>
     public static Task<VerifyResult> VerifyDirectory(
@@ -43,7 +43,7 @@ public static partial class Verifier
 #else
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public static Task<VerifyResult> VerifyDirectory(
         string name,
@@ -61,7 +61,7 @@ public static partial class Verifier
     }
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object target)</code> which will verify the full path.
     /// </summary>
     public static Task<VerifyResult> VerifyDirectory(

--- a/src/Verify.Expecto/Verifier_File.cs
+++ b/src/Verify.Expecto/Verifier_File.cs
@@ -5,7 +5,7 @@ namespace VerifyExpecto;
 public static partial class Verifier
 {
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public static Task<VerifyResult> VerifyFile(
         string name,
@@ -19,7 +19,7 @@ public static partial class Verifier
     }
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="FileInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public static Task<VerifyResult> VerifyFile(

--- a/src/Verify.MSTest/VerifyBase_Directory.cs
+++ b/src/Verify.MSTest/VerifyBase_Directory.cs
@@ -5,7 +5,7 @@ public partial class VerifyBase
 #if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public SettingsTask VerifyDirectory(
         string path,
@@ -19,7 +19,7 @@ public partial class VerifyBase
         Verify(settings, sourceFile, _ => _.VerifyDirectory(path, include, pattern, options, info, fileScrubber), true);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public SettingsTask VerifyDirectory(
@@ -35,7 +35,7 @@ public partial class VerifyBase
 #else
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public SettingsTask VerifyDirectory(
         string path,
@@ -49,7 +49,7 @@ public partial class VerifyBase
         Verify(settings, sourceFile, _ => _.VerifyDirectory(path, include, pattern, option, info, fileScrubber), true);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public SettingsTask VerifyDirectory(

--- a/src/Verify.MSTest/VerifyBase_File.cs
+++ b/src/Verify.MSTest/VerifyBase_File.cs
@@ -3,7 +3,7 @@
 public partial class VerifyBase
 {
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public SettingsTask VerifyFile(
         string path,
@@ -13,7 +13,7 @@ public partial class VerifyBase
         Verify(settings, sourceFile, _ => _.VerifyFile(path, info));
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="FileInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public SettingsTask VerifyFile(

--- a/src/Verify.NUnit/Verifier_Directory.cs
+++ b/src/Verify.NUnit/Verifier_Directory.cs
@@ -5,7 +5,7 @@ public static partial class Verifier
 #if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public static SettingsTask VerifyDirectory(
         string path,
@@ -19,7 +19,7 @@ public static partial class Verifier
         Verify(settings, sourceFile, _ => _.VerifyDirectory(path, include, pattern, options, info, fileScrubber), true);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public static SettingsTask VerifyDirectory(
@@ -36,7 +36,7 @@ public static partial class Verifier
 #else
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public static SettingsTask VerifyDirectory(
         string path,
@@ -54,7 +54,7 @@ public static partial class Verifier
             true);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public static SettingsTask VerifyDirectory(

--- a/src/Verify.NUnit/Verifier_File.cs
+++ b/src/Verify.NUnit/Verifier_File.cs
@@ -3,7 +3,7 @@
 public static partial class Verifier
 {
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public static SettingsTask VerifyFile(
         string path,
@@ -13,7 +13,7 @@ public static partial class Verifier
         Verify(settings, sourceFile, _ => _.VerifyFile(path, info));
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="FileInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public static SettingsTask VerifyFile(

--- a/src/Verify.NUnit/VerifyBase_Directory.cs
+++ b/src/Verify.NUnit/VerifyBase_Directory.cs
@@ -5,7 +5,7 @@ public partial class VerifyBase
 #if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public SettingsTask VerifyDirectory(
         string path,
@@ -26,7 +26,7 @@ public partial class VerifyBase
             sourceFile);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public SettingsTask VerifyDirectory(
@@ -50,7 +50,7 @@ public partial class VerifyBase
 #else
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public SettingsTask VerifyDirectory(
         string path,
@@ -71,7 +71,7 @@ public partial class VerifyBase
             sourceFile);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public SettingsTask VerifyDirectory(

--- a/src/Verify.NUnit/VerifyBase_File.cs
+++ b/src/Verify.NUnit/VerifyBase_File.cs
@@ -3,7 +3,7 @@
 public partial class VerifyBase
 {
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public SettingsTask VerifyFile(
         string path,
@@ -12,7 +12,7 @@ public partial class VerifyBase
         Verifier.VerifyFile(path, settings ?? this.settings, info, sourceFile);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="FileInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public SettingsTask VerifyFile(

--- a/src/Verify.Xunit/Verifier_Directory.cs
+++ b/src/Verify.Xunit/Verifier_Directory.cs
@@ -5,7 +5,7 @@ public static partial class Verifier
 #if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public static SettingsTask VerifyDirectory(
         string path,
@@ -19,7 +19,7 @@ public static partial class Verifier
         Verify(settings, sourceFile, _ => _.VerifyDirectory(path, include, pattern, options, info, fileScrubber), true);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public static SettingsTask VerifyDirectory(
@@ -36,7 +36,7 @@ public static partial class Verifier
 #else
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public static SettingsTask VerifyDirectory(
         string path,
@@ -54,7 +54,7 @@ public static partial class Verifier
             true);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public static SettingsTask VerifyDirectory(

--- a/src/Verify.Xunit/Verifier_File.cs
+++ b/src/Verify.Xunit/Verifier_File.cs
@@ -3,7 +3,7 @@
 public static partial class Verifier
 {
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public static SettingsTask VerifyFile(
         string path,
@@ -13,7 +13,7 @@ public static partial class Verifier
         Verify(settings, sourceFile, _ => _.VerifyFile(path, info));
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="FileInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public static SettingsTask VerifyFile(

--- a/src/Verify.Xunit/VerifyBase_Directory.cs
+++ b/src/Verify.Xunit/VerifyBase_Directory.cs
@@ -5,7 +5,7 @@ public partial class VerifyBase
 #if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public SettingsTask VerifyDirectory(
         string path,
@@ -26,7 +26,7 @@ public partial class VerifyBase
             sourceFile);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public SettingsTask VerifyDirectory(
@@ -50,7 +50,7 @@ public partial class VerifyBase
 #else
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public SettingsTask VerifyDirectory(
         string path,
@@ -71,7 +71,7 @@ public partial class VerifyBase
             sourceFile);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="DirectoryInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public SettingsTask VerifyDirectory(

--- a/src/Verify.Xunit/VerifyBase_File.cs
+++ b/src/Verify.Xunit/VerifyBase_File.cs
@@ -3,7 +3,7 @@
 public partial class VerifyBase
 {
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// </summary>
     public SettingsTask VerifyFile(
         string path,
@@ -12,7 +12,7 @@ public partial class VerifyBase
         Verifier.VerifyFile(path, settings ?? this.settings, info, sourceFile);
 
     /// <summary>
-    /// Verifies the contents of <param name="path"/>.
+    /// Verifies the contents of <paramref name="path"/>.
     /// Differs from passing <see cref="FileInfo"/> to <code>Verify(object? target)</code> which will verify the full path.
     /// </summary>
     public SettingsTask VerifyFile(


### PR DESCRIPTION
Otherwise, the `path` gets lost from IDEs like Rider :(

Before:
<img width="353" alt="image" src="https://github.com/VerifyTests/Verify/assets/92793/a353f3ee-585f-4214-872f-b2966218ec4a">

After:
<img width="459" alt="image" src="https://github.com/VerifyTests/Verify/assets/92793/3e1fc335-f01e-49e4-bea6-53931412b755">
