### PR TITLE
Bugfix for VerifyXml

### DIFF
--- a/src/Verify.Tests/XmlTests.EmptyTag.verified.xml
+++ b/src/Verify.Tests/XmlTests.EmptyTag.verified.xml
@@ -1,0 +1,4 @@
+﻿<body>
+  <empty />
+  <node>text</node>
+</body>

--- a/src/Verify.Tests/XmlTests.EmptyTagWithAttributes.verified.xml
+++ b/src/Verify.Tests/XmlTests.EmptyTagWithAttributes.verified.xml
@@ -1,0 +1,4 @@
+﻿<body>
+  <empty id="Guid_1" att="asdf" />
+  <node>text</node>
+</body>

--- a/src/Verify.Tests/XmlTests.IgnoreAttribute.verified.xml
+++ b/src/Verify.Tests/XmlTests.IgnoreAttribute.verified.xml
@@ -1,3 +1,3 @@
 ﻿<body>
-  <node att="Scrubbed"></node>
+  <node att="Scrubbed" />
 </body>

--- a/src/Verify.Tests/XmlTests.ScrubAttribute.verified.xml
+++ b/src/Verify.Tests/XmlTests.ScrubAttribute.verified.xml
@@ -1,3 +1,3 @@
 ﻿<body>
-  <node></node>
+  <node />
 </body>

--- a/src/Verify.Tests/XmlTests.cs
+++ b/src/Verify.Tests/XmlTests.cs
@@ -110,4 +110,12 @@ public class XmlTests
     public Task XDocScrubMember() =>
         Verify(XDocument.Parse(xml))
             .ScrubMember("node");
+
+    [Fact]
+    public Task EmptyTag() =>
+        VerifyXml("<body><empty /><node>text</node></body>");
+
+    [Fact]
+    public Task EmptyTagWithAttributes() =>
+        VerifyXml($@"<body><empty id=""{Guid.NewGuid()}"" att=""asdf"" /><node>text</node></body>");
 }

--- a/src/Verify/Verifier/InnerVerifier_Xml.cs
+++ b/src/Verify/Verifier/InnerVerifier_Xml.cs
@@ -96,7 +96,7 @@ partial class InnerVerifier
                 attribute.Value = ConvertValue(serialization, attribute.Value);
             }
 
-            if (node.HasElements)
+            if (node.IsEmpty || node.HasElements)
             {
                 continue;
             }


### PR DESCRIPTION
Method VerifyXml doesn't work correctly with empty xml tags as described in #935. Here is a fix for this problem.