### PR TITLE
Explicitly reject unbounded streams

### DIFF
--- a/docs/verify-file.md
+++ b/docs/verify-file.md
@@ -16,7 +16,7 @@ Verifies the contents of a file.
 public Task VerifyFilePath() =>
     VerifyFile("sample.txt");
 ```
-<sup><a href='/src/Verify.Tests/StreamTests.cs#L165-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifyfile' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/StreamTests.cs#L179-L185' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifyfile' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -33,7 +33,7 @@ public Task VerifyFileWithInfo() =>
         "sample.txt",
         info: "the info");
 ```
-<sup><a href='/src/Verify.Tests/StreamTests.cs#L184-L192' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifyfilewithinfo' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/StreamTests.cs#L198-L206' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifyfilewithinfo' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/verify-xml.md
+++ b/docs/verify-xml.md
@@ -19,7 +19,7 @@ Verifies Xml:
 public Task VerifyFilePath() =>
     VerifyFile("sample.txt");
 ```
-<sup><a href='/src/Verify.Tests/StreamTests.cs#L165-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifyfile' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/StreamTests.cs#L179-L185' title='Snippet source file'>snippet source</a> | <a href='#snippet-verifyfile' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Shared.sln.DotSettings
+++ b/src/Shared.sln.DotSettings
@@ -30,7 +30,6 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PatternIsAlwaysTrueOrFalse/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantStringInterpolation/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RawStringCanBeSimplified/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantTypeDeclarationBody/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective_002EGlobal/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SeparateLocalFunctionsWithJumpStatement/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringLiteralAsInterpolationArgument/@EntryIndexedValue">ERROR</s:String>

--- a/src/Verify.Tests/StreamTests.UnboundedStream.verified.txt
+++ b/src/Verify.Tests/StreamTests.UnboundedStream.verified.txt
@@ -1,0 +1,4 @@
+﻿{
+  Type: ArgumentException,
+  Message: Could not read Length property of target stream. Verify does not support unbounded streams.
+}

--- a/src/Verify.Tests/StreamTests.cs
+++ b/src/Verify.Tests/StreamTests.cs
@@ -124,6 +124,20 @@ public class StreamTests
     }
 
     [Fact]
+    public Task UnboundedStream()
+    {
+        var stream = new MemoryStream(new byte[]
+        {
+            1
+        });
+        var unboundedStream = new UnboundedStream(stream);
+
+        return ThrowsTask(() => Verify(unboundedStream))
+            .DisableRequireUniquePrefix()
+            .IgnoreStackTrace();
+    }
+
+    [Fact]
     public Task Streams() =>
         Verify(
             new List<Stream>

--- a/src/Verify.Tests/UnboundedStream.cs
+++ b/src/Verify.Tests/UnboundedStream.cs
@@ -1,0 +1,28 @@
+﻿class UnboundedStream(Stream inner) : Stream
+{
+    public override void Flush() =>
+        inner.Flush();
+
+    public override long Seek(long offset, SeekOrigin origin) =>
+        throw new NotImplementedException();
+
+    public override void SetLength(long value) =>
+        throw new NotImplementedException();
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        inner.Read(buffer, offset, count);
+
+    public override void Write(byte[] buffer, int offset, int count) =>
+        throw new NotImplementedException();
+
+    public override bool CanRead => inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotImplementedException();
+
+    public override long Position
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+}

--- a/src/Verify/Verifier/InnerVerifier_Stream.cs
+++ b/src/Verify/Verifier/InnerVerifier_Stream.cs
@@ -84,9 +84,16 @@ partial class InnerVerifier
 
         using (stream)
         {
-            if (stream.Length == 0)
+            try
             {
-                throw new("Empty data is not allowed.");
+                if (stream.Length == 0)
+                {
+                    throw new("Empty data is not allowed.");
+                }
+            }
+            catch (NotImplementedException)
+            {
+                throw new ArgumentException("Could not read Length property of target stream. Verify does not support unbounded streams.");
             }
 
             if (VerifierSettings.HasExtensionConverter(extension))

--- a/src/Verify/Verifier/VerifyException.cs
+++ b/src/Verify/Verifier/VerifyException.cs
@@ -1,10 +1,5 @@
-﻿class VerifyException :
-    Exception
+﻿class VerifyException(string message) :
+    Exception(message)
 {
-    public VerifyException(string message) :
-        base(message)
-    {
-    }
-
     public override string StackTrace => "";
 }


### PR DESCRIPTION
Currently, attempting to verify a stream for which the Length property getter is not implemented results in:

```
System.NotSupportedException
Specified method is not supported.
   at System.Net.Http.HttpBaseStream.get_Length()
```

This PR handles this case explicitly.

The update to the .dotsettings file occurred during rebuild. I assume it's the result of an updated settings package, but please verify (lololol) that this change is correct.
