### PR TITLE
A Test reproducing an exception where the message requests a PR

### DIFF
--- a/src/Verify.NUnit.Tests/VerifyInSetUp.Should_test.verified.txt
+++ b/src/Verify.NUnit.Tests/VerifyInSetUp.Should_test.verified.txt
@@ -1,0 +1,1 @@
+﻿I can call verify in SetUp, and the test method is known.

--- a/src/Verify.NUnit.Tests/VerifyInSetup.cs
+++ b/src/Verify.NUnit.Tests/VerifyInSetup.cs
@@ -1,0 +1,31 @@
+public class VerifyInSetUp
+{
+    [SetUp]
+    public async Task SetUp()
+    {
+        await Verify("I can call verify in SetUp, and the test method is known.");
+    }
+
+    [Test]
+    public void Should_test()
+    {
+        Assert.Pass();
+    }
+}
+
+public class VerifyInOneTimeSetUp
+{
+    [OneTimeSetUp]
+    public async Task SetUp()
+    {
+        // var ex = Assert.ThrowsAsync<InvalidOperationException>(() => Verify("If I call verify in One Time SetUp the test method is not known. This should probably be an IllegalStateException"))!;
+        // Assert.That(ex.Message, Is.EqualTo("Executing Verify in a One Time Setup method is not supported. Please run Verify in a test method."));
+        await Verify(Verify("If I call verify in One Time SetUp the test method is not known. This should probably be an IllegalStateException"));
+    }
+
+    [Test]
+    public void Should_test()
+    {
+        Assert.Pass();
+    }
+}

--- a/src/Verify.NUnit.Tests/VerifyInSetup.cs
+++ b/src/Verify.NUnit.Tests/VerifyInSetup.cs
@@ -1,31 +1,30 @@
-public class VerifyInSetUp
+public class VerifyInTestSetUp
 {
     [SetUp]
     public async Task SetUp()
     {
-        await Verify("I can call verify in SetUp, and the test method is known.");
+        await Verify("I can call verify in a SetUp method, and the test fixture and test method is available for the verify file name.");
     }
 
     [Test]
-    public void Should_test()
+    public void IsVerified()
     {
-        Assert.Pass();
+        Assert.Pass("Setup method is invoked before each test");
     }
 }
 
 public class VerifyInOneTimeSetUp
 {
     [OneTimeSetUp]
-    public async Task SetUp()
+    public void SetUp()
     {
-        // var ex = Assert.ThrowsAsync<InvalidOperationException>(() => Verify("If I call verify in One Time SetUp the test method is not known. This should probably be an IllegalStateException"))!;
-        // Assert.That(ex.Message, Is.EqualTo("Executing Verify in a One Time Setup method is not supported. Please run Verify in a test method."));
-        await Verify(Verify("If I call verify in One Time SetUp the test method is not known. This should probably be an IllegalStateException"));
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(() => Verify("If I call verify in a fixtures One Time SetUp method, then test method is not available for the verify file name."))!;
+        Assert.That(ex.Message, Is.EqualTo("Executing Verify in a One Time Setup method is not supported. Please run Verify in a test method."));
     }
 
     [Test]
-    public void Should_test()
+    public void ThrowsInvalidOperationException()
     {
-        Assert.Pass();
+        Assert.Pass("Verify is not available");
     }
 }

--- a/src/Verify.NUnit.Tests/VerifyInTestSetUp.IsVerified.verified.txt
+++ b/src/Verify.NUnit.Tests/VerifyInTestSetUp.IsVerified.verified.txt
@@ -1,0 +1,1 @@
+﻿I can call verify in a SetUp method, and the test fixture and test method is available for the verify file name.

--- a/src/Verify.NUnit/Verifier.cs
+++ b/src/Verify.NUnit/Verifier.cs
@@ -21,16 +21,13 @@ public static partial class Verifier
         }
         var context = TestContext.CurrentContext;
         var adapter = context.Test;
-
-        // Suggested possible fix to clarify that running in One Time Setup is not supported
-        // if (field.GetValue(adapter) is TestFixture)
-        // {
-        //     throw new InvalidOperationException("Executing Verify in a One Time Setup method is not supported. Please run Verify in a test method.");
-        // }
-
         var test = (Test) field.GetValue(adapter)!;
         var typeInfo = test.TypeInfo;
 
+        if (field.GetValue(adapter) is TestFixture)
+        {
+            throw new InvalidOperationException("Executing Verify in a One Time Setup method is not supported. Please run Verify in a test method.");
+        }
         if (typeInfo is null || test.Method is null)
         {
             throw new("Expected Test.TypeInfo and Test.Method to not be null. Submit a Pull Request with a test that replicates this problem.");

--- a/src/Verify.NUnit/Verifier.cs
+++ b/src/Verify.NUnit/Verifier.cs
@@ -21,8 +21,16 @@ public static partial class Verifier
         }
         var context = TestContext.CurrentContext;
         var adapter = context.Test;
+
+        // Suggested possible fix to clarify that running in One Time Setup is not supported
+        // if (field.GetValue(adapter) is TestFixture)
+        // {
+        //     throw new InvalidOperationException("Executing Verify in a One Time Setup method is not supported. Please run Verify in a test method.");
+        // }
+
         var test = (Test) field.GetValue(adapter)!;
         var typeInfo = test.TypeInfo;
+
         if (typeInfo is null || test.Method is null)
         {
             throw new("Expected Test.TypeInfo and Test.Method to not be null. Submit a Pull Request with a test that replicates this problem.");


### PR DESCRIPTION
This is a PICNIC problem, but since the exception asked for steps to replicate the exception, it seems as though you would like to defend against it. I added a comment suggesting a possible guard clause to defend against the unexpected configuration.

Hope this helps:

Behavior seen in target frameworks net 7.0 and net 481
Verify.Nunit v 22.1.4

I created a class with a Verify condition in the Setup method:
```
public class VerifyInSetup
{
    [SetUp]
    public async Task SetUp()
    {
        await Verify("SetUp");
    }
    
    [Test]
    public void Should_test()
    {
        Assert.Pass();
    }
}
```

When I ran this I saw that the following approval test files are created
VerifyInSetup.Should_test.received.txt
VerifyInSetup.Should_test.verified.txt
The diff tool comparison appeared and I was able to verify the input string. 
Future test runs all passed without approval.

I created another class with a Verify condition in the OneTimeSetUp method:
```
public class VerifyInOneTimeSetUp
{
    [OneTimeSetUp]
    public async Task SetUp()
    {
        await Verify("One Time SetUp");
    }
    
    [Test]
    public void Should_test()
    {
        Assert.Pass();
    }
}
```

When I ran this test I saw the following exception logged in the output window:

```
System.Exception : Expected Test.TypeInfo and Test.Method to not be null. Submit a Pull Request with a test that replicates this problem.
   at VerifyNUnit.Verifier.BuildVerifier(String sourceFile, VerifySettings settings, Boolean useUniqueDirectory) in /_/src/Verify.NUnit/Verifier.cs:line 28
   at VerifyNUnit.Verifier.<>c__DisplayClass10_0.<<Verify>b__0>d.MoveNext() in /_/src/Verify.NUnit/Verifier.cs:line 103
--- End of stack trace from previous location ---
   at ApprovalTest.Tests.VerifyInOneTimeSetUp.SetUp() in C:\kata\ApprovalTests\ApprovalTest\ApprovalTest.Tests\VerifyInOneTimeSetUp.cs:line 8
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.GetResult()
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.SetUpTearDownItem.RunSetUpOrTearDownMethod(TestExecutionContext context, IMethodInfo method)
   at NUnit.Framework.Internal.Commands.SetUpTearDownItem.RunSetUp(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.OneTimeSetUpCommand.<>c__DisplayClass0_0.<.ctor>b__0(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeTestCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeTestCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformOneTimeSetUp()
```

I don't really know what I expected,
(I was working in some legacy code, with a long one time setup method, I was trying to see what the state of the system was, and didn't notice that I wasn't in a test method)

A message indicating that Verify is not supported in OneTimeSetup would be nice.