### PR TITLE
Use await using

### DIFF
--- a/src/Verify/IoHelpers.cs
+++ b/src/Verify/IoHelpers.cs
@@ -1,4 +1,4 @@
-﻿static class IoHelpers
+static class IoHelpers
 {
     static readonly char[] Separators =
     [
@@ -17,7 +17,7 @@
     public static void DeleteFileIfEmpty(string path)
     {
         var info = new FileInfo(path);
-        if (info is {Exists: true, Length: 0})
+        if (info is { Exists: true, Length: 0 })
         {
             info.Delete();
         }
@@ -198,7 +198,7 @@
 
     public static async Task<StringBuilder> ReadStringBuilderWithFixedLines(string path)
     {
-        using var stream = OpenRead(path);
+        await using var stream = OpenRead(path);
         return await stream.ReadStringBuilderWithFixedLines();
     }
 
@@ -217,7 +217,7 @@
         }
 
         // keep using scope to stream is flushed
-        using (var targetStream = OpenWrite(path))
+        await using (var targetStream = OpenWrite(path))
         {
             await stream.SafeCopy(targetStream);
         }

--- a/src/Verify/SettingsTask.cs
+++ b/src/Verify/SettingsTask.cs
@@ -1,4 +1,4 @@
-﻿namespace VerifyTests;
+namespace VerifyTests;
 
 public partial class SettingsTask
 {
@@ -66,7 +66,7 @@ public partial class SettingsTask
 
     /// <summary>
     /// Define the parameter values being used by a parameterised (aka data drive) test.
-    /// In most cases the parameter parameter values can be automatically resolved.
+    /// In most cases the parameter values can be automatically resolved.
     /// When this is not possible, an exception will be thrown instructing the use of <see cref="UseParameters" />
     /// Not compatible with <see cref="UseTextForParameters" />.
     /// </summary>


### PR DESCRIPTION
Similar as using (...) uses IDisposable to clean up resources, await using (...) uses [IAsyncDisposable](https://learn.microsoft.com/en-us/dotnet/api/system.iasyncdisposable?view=dotnet-plat-ext-3.0). This allows to perform also time-consuming tasks (e.g involving I/O) on cleanup without blocking.