### PR TITLE
Use MSTest metapackage to simplify MSTest setup

### DIFF
--- a/docs/wiz/Linux_Other_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_AppVeyor.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Linux_Other_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_AzureDevOps.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Linux_Other_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_GitHubActions.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Linux_Other_Gui_MSTest_None.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_None.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Linux_Rider_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_AppVeyor.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Linux_Rider_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_AzureDevOps.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Linux_Rider_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_GitHubActions.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Linux_Rider_Gui_MSTest_None.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_None.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/MacOS_Other_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_AppVeyor.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/MacOS_Other_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_AzureDevOps.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/MacOS_Other_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_GitHubActions.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/MacOS_Other_Gui_MSTest_None.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_None.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_AppVeyor.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_AzureDevOps.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_GitHubActions.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_None.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_Other_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_AppVeyor.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_Other_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_AzureDevOps.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_Other_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_GitHubActions.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_Other_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_None.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_Rider_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_AppVeyor.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_Rider_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_AzureDevOps.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_Rider_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_GitHubActions.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_Rider_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_None.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AppVeyor.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AzureDevOps.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_GitHubActions.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_None.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_AppVeyor.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_AzureDevOps.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_GitHubActions.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_None.md
@@ -17,12 +17,10 @@ Add the following packages to the test project:
 <!-- snippet: mstest-nugets -->
 <a id='snippet-mstest-nugets'></a>
 ```csproj
-<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-<PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-<PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+<PackageReference Include="MSTest" Version="3.3.1" />
 <PackageReference Include="Verify.MSTest" Version="24.2.0" />
 ```
-<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj#L7-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-mstest-nugets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj
+++ b/src/NugetUsage/MSTestNugetUsage/MSTestNugetUsage.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- begin-snippet: mstest-nugets -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
     <PackageReference Include="Verify.MSTest" Version="24.2.0" />
     <!-- end-snippet -->
   </ItemGroup>

--- a/src/Verify.MSTest.Tests/Verify.MSTest.Tests.csproj
+++ b/src/Verify.MSTest.Tests/Verify.MSTest.Tests.csproj
@@ -7,9 +7,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
     <PackageReference Include="ProjectDefaults" Version="1.0.127" PrivateAssets="all" />
     <ProjectReference Include="..\TargetLibrary\TargetLibrary.csproj" />
     <ProjectReference Include="..\Verify.MSTest\Verify.MSTest.csproj" />


### PR DESCRIPTION
Use the `MSTest` metapackage, which includes:

- `Microsoft.NET.Test.Sdk`
- `MSTest.Analyzers`
- `MSTest.TestAdapter`
- `MSTest.TestFramework`

In addition to including the analyzers package, this simplifies the dependencies and setup.