### PR TITLE
Make MSTest.SourceGenerator thread-safe

### DIFF
--- a/src/Verify.MSTest.SourceGenerator/Emitter.cs
+++ b/src/Verify.MSTest.SourceGenerator/Emitter.cs
@@ -13,8 +13,6 @@ static class Emitter
     static readonly string GeneratedCodeAttribute =
         $"[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"{typeof(Emitter).Assembly.GetName().Name}\", \"{typeof(Emitter).Assembly.GetName().Version}\")]";
 
-    static readonly IndentedStringBuilder IndentedStringBuilder = new();
-
     static void WriteNamespace(IndentedStringBuilder builder, ClassToGenerate classToGenerate)
     {
         if (classToGenerate.Namespace is not null)
@@ -65,15 +63,15 @@ static class Emitter
 
     public static string GenerateExtensionClasses(IReadOnlyCollection<ClassToGenerate> classesToGenerate)
     {
-        IndentedStringBuilder.Clear();
-        IndentedStringBuilder.AppendLine(AutoGenerationHeader);
+        var builder = new IndentedStringBuilder();
+        builder.AppendLine(AutoGenerationHeader);
 
         foreach (var classToGenerate in classesToGenerate)
         {
-            IndentedStringBuilder.AppendLine();
-            WriteNamespace(IndentedStringBuilder, classToGenerate);
+            builder.AppendLine();
+            WriteNamespace(builder, classToGenerate);
         }
 
-        return IndentedStringBuilder.ToString();
+        return builder.ToString();
     }
 }

--- a/src/Verify.MSTest.SourceGenerator/UsesVerifyGenerator.cs
+++ b/src/Verify.MSTest.SourceGenerator/UsesVerifyGenerator.cs
@@ -40,7 +40,7 @@ public class UsesVerifyGenerator : IIncrementalGenerator
 
         cancel.ThrowIfCancellationRequested();
 
-        return Parser.Parse(symbol, syntax);
+        return Parser.Parse(symbol, syntax, cancel);
     }
 
     static void Execute(SourceProductionContext context, ImmutableArray<ClassToGenerate?> classesToGenerate)
@@ -56,9 +56,11 @@ public class UsesVerifyGenerator : IIncrementalGenerator
             return;
         }
 
-        context.CancellationToken.ThrowIfCancellationRequested();
+        var cancel = context.CancellationToken;
+        cancel.ThrowIfCancellationRequested();
 
-        var sourceCode = Emitter.GenerateExtensionClasses(classes);
+        var emitter = new Emitter();
+        var sourceCode = emitter.GenerateExtensionClasses(classes, cancel);
         context.AddSource("UsesVerify.g.cs", SourceText.From(sourceCode, Encoding.UTF8));
     }
 }

--- a/src/Verify.MSTest.SourceGenerator/UsesVerifyGenerator.cs
+++ b/src/Verify.MSTest.SourceGenerator/UsesVerifyGenerator.cs
@@ -56,6 +56,8 @@ public class UsesVerifyGenerator : IIncrementalGenerator
             return;
         }
 
+        context.CancellationToken.ThrowIfCancellationRequested();
+
         var sourceCode = Emitter.GenerateExtensionClasses(classes);
         context.AddSource("UsesVerify.g.cs", SourceText.From(sourceCode, Encoding.UTF8));
     }


### PR DESCRIPTION
The `Execute` method on `IIncrementalSourceGenerator` is re-entrant (most easily reproducible by adding `Thread.Sleep()`s). Thus, the StringBuilder can't be static, or the competing compilations may corrupt each other's source.

Additionally, I plumbed the `CancellationToken` into more places to more closely follow the guidance from the [Incremental Generators Cookbook](https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.cookbook.md).

To make the Emitter code a little easier to follow I made it an instance class. This is also what the LoggingMessage generator does (see https://github.com/dotnet/runtime/blob/af11dbc1a34538d9a38d39a7c96ddd5e7fc6907b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Roslyn4.0.cs#L54-L57).