### PR TITLE
Don't reference System.IO.Compression package

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -27,7 +27,6 @@
     <PackageVersion Include="PublicApiGenerator" Version="11.1.0" />
     <PackageVersion Include="SimpleInfoName" Version="2.2.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.6" />
-    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/Verify.ExceptionParsing.Tests/Verify.ExceptionParsing.Tests.csproj
+++ b/src/Verify.ExceptionParsing.Tests/Verify.ExceptionParsing.Tests.csproj
@@ -1,19 +1,28 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net9.0</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
+
     <ProjectReference Include="..\Verify.ExceptionParsing\Verify.ExceptionParsing.csproj" />
     <ProjectReference Include="..\Verify.Xunit\Verify.Xunit.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
+
 </Project>

--- a/src/Verify.Fixie/Verify.Fixie.csproj
+++ b/src/Verify.Fixie/Verify.Fixie.csproj
@@ -1,18 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <TestProject>false</TestProject>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Fixie" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />
+
     <ProjectReference Include="..\Verify\Verify.csproj" PrivateAssets="None" />
+
     <None Include="buildTransitive\Verify.Fixie.props" Pack="true" PackagePath="buildTransitive\Verify.Fixie.props" />
     <None Include="buildTransitive\Verify.Fixie.props" Pack="true" PackagePath="build\Verify.Fixie.props" />
+
     <Compile Include="..\Verify\Guard.cs" />
     <Compile Include="..\Verify\Extensions.cs" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
 </Project>

--- a/src/Verify.MSTest.Tests/Verify.MSTest.Tests.csproj
+++ b/src/Verify.MSTest.Tests/Verify.MSTest.Tests.csproj
@@ -1,20 +1,29 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net9.0</TargetFrameworks>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="MSTest" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
+
     <ProjectReference Include="..\TargetLibrary\TargetLibrary.csproj" />
     <ProjectReference Include="..\Verify.MSTest\Verify.MSTest.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
     <ProjectReference Include="..\Verify.MSTest.SourceGenerator\Verify.MSTest.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.MSTest\buildTransitive\Verify.MSTest.props" />
+
 </Project>

--- a/src/Verify.MSTest/Verify.MSTest.csproj
+++ b/src/Verify.MSTest/Verify.MSTest.csproj
@@ -1,14 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net472;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net472;net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
     <PackageReference Include="MSTest.TestFramework" />
+
     <ProjectReference Include="..\Verify\Verify.csproj" PrivateAssets="None" />
     <ProjectReference Include="..\Verify.MSTest.SourceGenerator\Verify.MSTest.SourceGenerator.csproj" ReferenceOutputAssembly="false" PackAsAnalyzer="true" OutputItemType="Analyzer" />
+
     <None Include="buildTransitive\Verify.MSTest.props" Pack="true" PackagePath="buildTransitive\Verify.MSTest.props" />
     <None Include="buildTransitive\Verify.MSTest.props" Pack="true" PackagePath="build\Verify.MSTest.props" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
 </Project>

--- a/src/Verify.NUnit.Tests/Verify.NUnit.Tests.csproj
+++ b/src/Verify.NUnit.Tests/Verify.NUnit.Tests.csproj
@@ -1,21 +1,31 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net9.0</TargetFrameworks>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
+
     <ProjectReference Include="..\TargetLibrary\TargetLibrary.csproj" />
     <ProjectReference Include="..\Verify.NUnit\Verify.NUnit.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
+
     <Using Include="NUnit.Framework.Legacy.ClassicAssert" Static="True" />
     <Using Include="NUnit.Framework.Assert" Static="True" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.NUnit\buildTransitive\Verify.NUnit.props" />
+
 </Project>

--- a/src/Verify.NUnit/Verify.NUnit.csproj
+++ b/src/Verify.NUnit/Verify.NUnit.csproj
@@ -1,13 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net472;net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NUnit" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
+
     <ProjectReference Include="..\Verify\Verify.csproj" PrivateAssets="None" />
+
     <None Include="buildTransitive\Verify.NUnit.props" Pack="true" PackagePath="buildTransitive\Verify.NUnit.props" />
     <None Include="buildTransitive\Verify.NUnit.props" Pack="true" PackagePath="build\Verify.NUnit.props" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
 </Project>

--- a/src/Verify.Tests/Verify.Tests.csproj
+++ b/src/Verify.Tests/Verify.Tests.csproj
@@ -1,5 +1,6 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48</TargetFrameworks>
     <TargetFrameworks>net9.0;net8.0;net7.0;$(TargetFrameworks)</TargetFrameworks>
@@ -7,6 +8,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Fody" PrivateAssets="all" />
     <PackageReference Include="InfoOf.Fody" />
@@ -16,11 +18,13 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="Xunit" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
+
     <ProjectReference Include="..\TargetLibrary\TargetLibrary.csproj" />
     <ProjectReference Include="..\Verify.ClipboardAccept\Verify.ClipboardAccept.csproj" />
     <ProjectReference Include="..\Verify.SamplePlugin\Verify.SamplePlugin.csproj" />
     <ProjectReference Include="..\Verify.Xunit\Verify.Xunit.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
+
     <None Update="sample*.*" CopyToOutputDirectory="PreserveNewest" />
     <None Update="Binary*.*.txt" CopyToOutputDirectory="PreserveNewest" />
     <Folder Include="Naming\CustomDirectory\" />
@@ -32,16 +36,25 @@
       <DependentUpon>AutoVerify.cs</DependentUpon>
     </None>
   </ItemGroup>
+
   <ItemGroup Condition="$(TargetFramework) != 'net7.0'">
     <Compile Remove="Wizard\WizardGen.cs" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
+
 </Project>

--- a/src/Verify.Xunit.Tests/Verify.Xunit.Tests.csproj
+++ b/src/Verify.Xunit.Tests/Verify.Xunit.Tests.csproj
@@ -1,23 +1,33 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net9.0</TargetFrameworks>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="PublicApiGenerator" />
     <PackageReference Include="Xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
+
     <ProjectReference Include="..\TargetLibrary\TargetLibrary.csproj" />
     <ProjectReference Include="..\Verify.Xunit\Verify.Xunit.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
+
     <Folder Include="Scrubbers\" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
+
 </Project>

--- a/src/Verify.Xunit/Verify.Xunit.csproj
+++ b/src/Verify.Xunit/Verify.Xunit.csproj
@@ -1,14 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net472;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net472;net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="xunit.abstractions" />
     <PackageReference Include="xunit.extensibility.execution" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
+
     <ProjectReference Include="..\Verify\Verify.csproj" PrivateAssets="None" />
+
     <None Include="buildTransitive\Verify.Xunit.props" Pack="true" PackagePath="buildTransitive\Verify.Xunit.props" />
     <None Include="buildTransitive\Verify.Xunit.props" Pack="true" PackagePath="build\Verify.Xunit.props" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
 </Project>

--- a/src/Verify/Verify.csproj
+++ b/src/Verify/Verify.csproj
@@ -1,21 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net472;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net472;net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Polyfill" PrivateAssets="all" />
-    <PackageReference Include="System.IO.Compression" Condition="$(TargetFrameworkIdentifier) == '.NETFramework'" />
-    <PackageReference Include="System.IO.Hashing" Condition="$(TargetFrameworkIdentifier) == '.NETFramework' or $(TargetFramework) == 'net6.0' or $(TargetFramework) == 'net7.0' or $(TargetFramework) == 'net8.0' or $(TargetFramework) == 'net9.0'" />
-    <PackageReference Include="System.Memory" Condition="$(TargetFrameworkIdentifier) == '.NETFramework'" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="$(TargetFrameworkIdentifier) == '.NETFramework'" />
+    <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="DiffEngine" />
     <PackageReference Include="SimpleInfoName" />
     <PackageReference Include="Argon" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
+
     <None Include="buildTransitive\Verify.props" Pack="true" PackagePath="buildTransitive\Verify.props" />
     <None Include="buildTransitive\Verify.targets" Pack="true" PackagePath="buildTransitive\Verify.targets" />
     <None Include="buildTransitive\Verify.props" Pack="true" PackagePath="build\Verify.props" />
     <None Include="buildTransitive\Verify.targets" Pack="true" PackagePath="build\Verify.targets" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
System.IO.Compression is inbox on .NET Framework. The package doesn't need to be referenced and will eventually be marked as deprecated.

<img width="245" alt="image" src="https://github.com/VerifyTests/Verify/assets/7412651/29c05b57-8baa-49ab-821c-7b2595b8c83c">


I also cleaned-up the project files as they were hard to read. I hope that's OK.