### PR TITLE
Update build-server-githubactions.include.md

### DIFF
--- a/docs/mdsource/build-server-githubactions.include.md
+++ b/docs/mdsource/build-server-githubactions.include.md
@@ -3,7 +3,7 @@ Use a [if: failure()](https://docs.github.com/en/free-pro-team@latest/actions/re
 ```yaml
 - name: Upload Test Results
   if: failure()
-  uses: actions/upload-artifact@v2
+  uses: actions/upload-artifact@v4
   with:
     name: verify-test-results
     path: |


### PR DESCRIPTION
actions/upload-artifact@v2 is deprecated (see https://github.com/actions/upload-artifact). Update to v4.