### PR TITLE
Show how to ignore class level params in NUnit tests

### DIFF
--- a/src/Verify.NUnit.Tests/IgnoreClassParamsForVerifiedTests.WithClassParamsIgnored.verified.txt
+++ b/src/Verify.NUnit.Tests/IgnoreClassParamsForVerifiedTests.WithClassParamsIgnored.verified.txt
@@ -1,0 +1,1 @@
+﻿Same value for any argument

--- a/src/Verify.NUnit.Tests/IgnoreClassParamsForVerifiedTests.cs
+++ b/src/Verify.NUnit.Tests/IgnoreClassParamsForVerifiedTests.cs
@@ -1,0 +1,15 @@
+[TestFixture("1")]
+[TestFixture("2")]
+public class IgnoreClassParamsForVerifiedTests(string arg)
+{
+    /// <summary>
+    /// IgnoreParametersForVerified only works on method params, not class params.
+    /// This test shows a workaround, using a combination of UseTypeName and DisableRequireUniquePrefix, that removes the class params from the output file name.
+    /// </summary>
+    [Test]
+    public async Task WithClassParamsIgnored() => await Verify("Same value for any argument")
+        .UseTypeName(GetType().Name)
+        .DisableRequireUniquePrefix();
+
+    private void SomeDummyConsumingTheArg() => Console.WriteLine(arg);
+}

--- a/src/Verify.NUnit.Tests/IgnoreLocalParamsForVerifiedTests.WithLocalParamsIgnored.verified.txt
+++ b/src/Verify.NUnit.Tests/IgnoreLocalParamsForVerifiedTests.WithLocalParamsIgnored.verified.txt
@@ -1,0 +1,1 @@
+﻿Same value for any argument

--- a/src/Verify.NUnit.Tests/IgnoreLocalParamsForVerifiedTests.cs
+++ b/src/Verify.NUnit.Tests/IgnoreLocalParamsForVerifiedTests.cs
@@ -1,0 +1,8 @@
+[TestFixture]
+public class IgnoreLocalParamsForVerifiedTests
+{
+    [Test]
+    [TestCase("1")]
+    [TestCase("2")]
+    public async Task WithLocalParamsIgnored(string arg) => await Verify("Same value for any argument").IgnoreParametersForVerified(arg);
+}


### PR DESCRIPTION
IgnoreParametersForVerified only works on method params, not class params.

This PR adds tests that show a workaround, using a combination of UseTypeName and DisableRequireUniquePrefix, to remove the class params from the output file name.