### PR TITLE
feat: added custom counter comparers

### DIFF
--- a/docs/scrubber-custom-comparers.md
+++ b/docs/scrubber-custom-comparers.md
@@ -12,7 +12,7 @@ void ReplaceScrubberTimeComparer(IEqualityComparer<Time> comparer)
 void ReplaceScrubberDateComparer(IEqualityComparer<Date> comparer)
 ```
 
-Example:
+Example with `Guid`:
 
 ```csharp
 private class StubGuidComparer : IEqualityComparer<Guid>
@@ -48,3 +48,36 @@ This test will create such `.verified.txt` file
 }
 ```
 
+Example with `DateTimeOffset` - comparison of Date part only:
+
+```csharp
+private class StubDateTimeOffsetComparer : IEqualityComparer<DateTimeOffset>
+{
+    public bool Equals(DateTimeOffset x, DateTimeOffset y) => x.Date == y.Date;
+
+    public int GetHashCode(DateTimeOffset obj) => 1;
+}
+
+[Fact]
+public async Task ShouldInjectCustomDateTimeOffsetComparer()
+{
+    var obj = new
+    {
+        Item1 = new DateTimeOffset(2023, 5, 1, 11, 5, 2, TimeSpan.FromHours(1)),
+        Item2 = new DateTimeOffset(2023, 5, 1, 12, 3, 1, TimeSpan.FromHours(1)),
+    };
+
+    var settings = new VerifySettings();
+    settings.ReplaceScrubberDateTimeOffsetComparer(new StubDateTimeOffsetComparer());
+    await Verify(obj, settings: settings);
+}
+```
+
+This test will create such `.verified.txt` file
+
+```text
+{
+  Item1: DateTimeOffset_1,
+  Item2: DateTimeOffset_1
+}
+```

--- a/docs/scrubber-custom-comparers.md
+++ b/docs/scrubber-custom-comparers.md
@@ -2,6 +2,18 @@
 
 In some cases you want to override default scrubber comparers.
 
+Available comparers replacements are:
+
+```csharp
+void ReplaceScrubberDateTimeOffsetComparer(IEqualityComparer<DateTimeOffset> comparer)
+void ReplaceScrubberGuidComparer(IEqualityComparer<Guid> comparer)
+void ReplaceScrubberDateTimeComparer(IEqualityComparer<DateTime> comparer)
+void ReplaceScrubberTimeComparer(IEqualityComparer<Time> comparer)
+void ReplaceScrubberDateComparer(IEqualityComparer<Date> comparer)
+```
+
+Example:
+
 ```csharp
 private class StubGuidComparer : IEqualityComparer<Guid>
 {
@@ -36,12 +48,3 @@ This test will create such `.verified.txt` file
 }
 ```
 
-Available comperers replacements are:
-
-```csharp
-void ReplaceScrubberDateTimeOffsetComparer(IEqualityComparer<DateTimeOffset> comparer)
-void ReplaceScrubberGuidComparer(IEqualityComparer<Guid> comparer)
-void ReplaceScrubberDateTimeComparer(IEqualityComparer<DateTime> comparer)
-void ReplaceScrubberTimeComparer(IEqualityComparer<Time> comparer)
-void ReplaceScrubberDateComparer(IEqualityComparer<Date> comparer)
-```

--- a/docs/scrubber-custom-comparers.md
+++ b/docs/scrubber-custom-comparers.md
@@ -1,0 +1,47 @@
+# Add custom comparer to a scrubber
+
+In some cases you want to override default scrubber comparers.
+
+```csharp
+private class StubGuidComparer : IEqualityComparer<Guid>
+{
+    public bool Equals(Guid x, Guid y) => true;
+
+    public int GetHashCode(Guid obj) => 1;
+}
+
+[Fact]
+public async Task ShouldInjectCustomGuidComparer()
+{
+    var obj = new
+    {
+        Item1 = Guid.NewGuid(),
+        Item2 = Guid.NewGuid(),
+        Item3 = Guid.NewGuid()
+    };
+
+    var settings = new VerifySettings();
+    settings.ReplaceScrubberGuidComparer(new StubGuidComparer());
+    await Verify(obj, settings: settings);
+}
+```
+
+This test will create such `.verified.txt` file
+
+```json
+{
+  Item1: Guid_1,
+  Item2: Guid_1,
+  Item3: Guid_1
+}
+```
+
+Available comperers replacements are:
+
+```csharp
+void ReplaceScrubberDateTimeOffsetComparer(IEqualityComparer<DateTimeOffset> comparer)
+void ReplaceScrubberGuidComparer(IEqualityComparer<Guid> comparer)
+void ReplaceScrubberDateTimeComparer(IEqualityComparer<DateTime> comparer)
+void ReplaceScrubberTimeComparer(IEqualityComparer<Time> comparer)
+void ReplaceScrubberDateComparer(IEqualityComparer<Date> comparer)
+```

--- a/docs/scrubber-custom-comparers.md
+++ b/docs/scrubber-custom-comparers.md
@@ -28,7 +28,7 @@ public async Task ShouldInjectCustomGuidComparer()
 
 This test will create such `.verified.txt` file
 
-```json
+```text
 {
   Item1: Guid_1,
   Item2: Guid_1,

--- a/readme.md
+++ b/readme.md
@@ -968,6 +968,7 @@ information sources and warn about particular gotchas:
   * [Parameterised tests](/docs/parameterised.md)
   * [Named Tuples](/docs/named-tuples.md)
   * [Scrubbers](/docs/scrubbers.md)
+  * [Scrubbers custom comparers](/docs/scrubber-custom-comparers.md)
   * [Diff Engine](https://github.com/VerifyTests/DiffEngine)
   * [Diff Tools](https://github.com/VerifyTests/DiffEngine/blob/master/docs/diff-tool.md)
   * [Diff Tool Order](https://github.com/VerifyTests/DiffEngine/blob/master/docs/diff-tool.order.md)

--- a/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomDateComparer.verified.txt
+++ b/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomDateComparer.verified.txt
@@ -1,0 +1,5 @@
+﻿{
+  Item1: Date_1,
+  Item2: Date_1,
+  Item3: Date_2
+}

--- a/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomDateTimeComparer.verified.txt
+++ b/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomDateTimeComparer.verified.txt
@@ -1,0 +1,6 @@
+﻿{
+  Item1: DateTime_1,
+  Item2: DateTime_1,
+  Item4: Guid_1,
+  Item5: Guid_2
+}

--- a/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomDateTimeOffsetComparer.verified.txt
+++ b/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomDateTimeOffsetComparer.verified.txt
@@ -1,0 +1,7 @@
+﻿{
+  Item1: DateTimeOffset_1,
+  Item2: DateTimeOffset_1,
+  Item3: DateTimeOffset_2,
+  Item4: Guid_1,
+  Item5: Guid_2
+}

--- a/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomGuidComparer.verified.txt
+++ b/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomGuidComparer.verified.txt
@@ -1,0 +1,5 @@
+﻿{
+  Item1: Guid_1,
+  Item2: Guid_1,
+  Item3: Guid_1
+}

--- a/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomTimeComparer.verified.txt
+++ b/src/Verify.Tests/CounterComparersTests.ShouldInjectCustomTimeComparer.verified.txt
@@ -1,0 +1,7 @@
+﻿{
+  Item1: Time_1,
+  Item2: Time_1,
+  Item3: Time_2,
+  Item4: Guid_1,
+  Item5: Guid_2
+}

--- a/src/Verify.Tests/CounterComparersTests.ShouldInjectMultipleComparers.verified.txt
+++ b/src/Verify.Tests/CounterComparersTests.ShouldInjectMultipleComparers.verified.txt
@@ -1,0 +1,7 @@
+﻿{
+  Item1: DateTimeOffset_1,
+  Item2: DateTimeOffset_1,
+  Item3: DateTimeOffset_1,
+  Item4: Guid_1,
+  Item5: Guid_1
+}

--- a/src/Verify.Tests/CounterComparersTests.cs
+++ b/src/Verify.Tests/CounterComparersTests.cs
@@ -1,0 +1,138 @@
+public class CounterComparersTests
+{
+    private class StubGuidComparer : IEqualityComparer<Guid>
+    {
+        public bool Equals(Guid x, Guid y) => true;
+
+        public int GetHashCode(Guid obj) => 1;
+    }
+
+    [Fact]
+    public async Task ShouldInjectCustomGuidComparer()
+    {
+        var obj = new
+        {
+            Item1 = Guid.NewGuid(),
+            Item2 = Guid.NewGuid(),
+            Item3 = Guid.NewGuid()
+        };
+
+        var settings = new VerifySettings();
+        settings.ReplaceScrubberGuidComparer(new StubGuidComparer());
+        await Verify(obj, settings: settings);
+    }
+
+#if NET6_0_OR_GREATER
+    private class StubDateComparer : IEqualityComparer<Date>
+    {
+        public bool Equals(Date x, Date y) => x.Year == y.Year;
+
+        public int GetHashCode(Date obj) => 1;
+    }
+
+    [Fact]
+    public async Task ShouldInjectCustomDateComparer()
+    {
+        var obj = new
+        {
+            Item1 = new Date(1999, 5, 1),
+            Item2 = new Date(1999, 12, 4),
+            Item3 = new Date(2666, 5, 1),
+        };
+
+        var settings = new VerifySettings();
+        settings.ReplaceScrubberDateComparer(new StubDateComparer());
+        await Verify(obj, settings: settings);
+    }
+
+    private class StubTimeComparer : IEqualityComparer<Time>
+    {
+        public bool Equals(Time x, Time y) => x.Hour == y.Hour;
+
+        public int GetHashCode(Time obj) => 1;
+    }
+
+    [Fact]
+    public async Task ShouldInjectCustomTimeComparer()
+    {
+        var obj = new
+        {
+            Item1 = new Time(23, 5, 1),
+            Item2 = new Time(23, 1, 1),
+            Item3 = new Time(1, 1, 1),
+            Item4 = Guid.NewGuid(),
+            Item5 = Guid.NewGuid()
+        };
+
+        var settings = new VerifySettings();
+        settings.ReplaceScrubberTimeComparer(new StubTimeComparer());
+        await Verify(obj, settings: settings);
+    }
+#endif
+
+    private class StubDateTimeComparer : IEqualityComparer<DateTime>
+    {
+        public bool Equals(DateTime x, DateTime y) => x.Year == y.Year;
+
+        public int GetHashCode(DateTime obj) => 1;
+    }
+
+    [Fact]
+    public async Task ShouldInjectCustomDateTimeComparer()
+    {
+        var obj = new
+        {
+            Item1 = new DateTime(23, 5, 1),
+            Item2 = new DateTime(23, 1, 1),
+            Item3 = new DateTime(1, 1, 1),
+            Item4 = Guid.NewGuid(),
+            Item5 = Guid.NewGuid()
+        };
+
+        var settings = new VerifySettings();
+        settings.ReplaceScrubberDateTimeComparer(new StubDateTimeComparer());
+        await Verify(obj, settings: settings);
+    }
+
+    private class StubDateTimeOffsetComparer : IEqualityComparer<DateTimeOffset>
+    {
+        public bool Equals(DateTimeOffset x, DateTimeOffset y) => x.Second == y.Second;
+
+        public int GetHashCode(DateTimeOffset obj) => 1;
+    }
+
+    [Fact]
+    public async Task ShouldInjectCustomDateTimeOffsetComparer()
+    {
+        var obj = new
+        {
+            Item1 = new DateTimeOffset(2021, 1, 1, 7, 1, 1, TimeSpan.FromHours(1)),
+            Item2 = new DateTimeOffset(2023, 5, 1, 1, 1, 1, TimeSpan.FromHours(1)),
+            Item3 = new DateTimeOffset(2024, 1, 6, 1, 2, 5, TimeSpan.FromHours(1)),
+            Item4 = Guid.NewGuid(),
+            Item5 = Guid.NewGuid()
+        };
+
+        var settings = new VerifySettings();
+        settings.ReplaceScrubberDateTimeOffsetComparer(new StubDateTimeOffsetComparer());
+        await Verify(obj, settings: settings);
+    }
+
+    [Fact]
+    public async Task ShouldInjectMultipleComparers()
+    {
+        var obj = new
+        {
+            Item1 = new DateTimeOffset(2021, 1, 1, 7, 1, 1, TimeSpan.FromHours(1)),
+            Item2 = new DateTimeOffset(2023, 5, 1, 1, 1, 1, TimeSpan.FromHours(1)),
+            Item3 = new DateTimeOffset(2024, 1, 6, 1, 2, 1, TimeSpan.FromHours(1)),
+            Item4 = Guid.NewGuid(),
+            Item5 = Guid.NewGuid()
+        };
+
+        var settings = new VerifySettings();
+        settings.ReplaceScrubberDateTimeOffsetComparer(new StubDateTimeOffsetComparer());
+        settings.ReplaceScrubberGuidComparer(new StubGuidComparer());
+        await Verify(obj, settings: settings);
+    }
+}

--- a/src/Verify/Counter.cs
+++ b/src/Verify/Counter.cs
@@ -34,7 +34,14 @@ public partial class Counter
 #endif
         Dictionary<DateTime, string> namedDateTimes,
         Dictionary<Guid, string> namedGuids,
-        Dictionary<DateTimeOffset, string> namedDateTimeOffsets)
+        Dictionary<DateTimeOffset, string> namedDateTimeOffsets,
+#if NET6_0_OR_GREATER
+        IEqualityComparer<Date> dateComparer,
+        IEqualityComparer<Time> timeComparer,
+#endif
+        IEqualityComparer<DateTime> dateTimeComparer,
+        IEqualityComparer<Guid> guidComparer,
+        IEqualityComparer<DateTimeOffset> dateTimeOffsetComparer)
     {
 #if NET6_0_OR_GREATER
         this.namedDates = namedDates;
@@ -44,6 +51,15 @@ public partial class Counter
         this.namedGuids = namedGuids;
         this.namedDateTimeOffsets = namedDateTimeOffsets;
         this.dateCounting = dateCounting;
+
+#if NET6_0_OR_GREATER
+        dateCache = new(dateComparer);
+        timeCache = new(timeComparer);
+#endif
+        Console.WriteLine("HELLO " + guidComparer);
+        dateTimeCache = new(dateTimeComparer);
+        guidCache = new(guidComparer);
+        dateTimeOffsetCache = new(dateTimeOffsetComparer);
     }
 
     internal static Counter Start(
@@ -54,7 +70,14 @@ public partial class Counter
 #endif
         Dictionary<DateTime, string>? namedDateTimes = null,
         Dictionary<Guid, string>? namedGuids = null,
-        Dictionary<DateTimeOffset, string>? namedDateTimeOffsets = null)
+        Dictionary<DateTimeOffset, string>? namedDateTimeOffsets = null,
+#if NET6_0_OR_GREATER
+        IEqualityComparer<Date>? dateComparer = null,
+        IEqualityComparer<Time>? timeComparer = null,
+#endif
+        IEqualityComparer<DateTime>? dateTimeComparer = null,
+        IEqualityComparer<Guid>? guidComparer = null,
+        IEqualityComparer<DateTimeOffset>? dateTimeOffsetComparer = null)
     {
         var context = new Counter(
             dateCounting,
@@ -64,7 +87,14 @@ public partial class Counter
 #endif
             namedDateTimes ?? [],
             namedGuids ?? [],
-            namedDateTimeOffsets ?? []);
+            namedDateTimeOffsets ?? [],
+#if NET6_0_OR_GREATER
+            dateComparer ?? new DateComparer(),
+            timeComparer ?? new TimeComparer(),
+#endif
+            dateTimeComparer ?? new DateTimeComparer(),
+            guidComparer ?? new GuidComparer(),
+            dateTimeOffsetComparer ?? new DateTimeOffsetComparer());
         local.Value = context;
         return context;
     }

--- a/src/Verify/Counter_Date.cs
+++ b/src/Verify/Counter_Date.cs
@@ -3,7 +3,7 @@ namespace VerifyTests;
 
 public partial class Counter
 {
-    Dictionary<Date, (int intValue, string stringValue)> dateCache = [];
+    Dictionary<Date, (int intValue, string stringValue)> dateCache;
     static Dictionary<Date, string> globalNamedDates = [];
     int currentDate;
 
@@ -11,6 +11,13 @@ public partial class Counter
     {
         InnerVerifier.ThrowIfVerifyHasBeenRun();
         globalNamedDates.Add(value, name);
+    }
+
+    class DateComparer : IEqualityComparer<Date>
+    {
+        public bool Equals(Date x, Date y) => x == y;
+
+        public int GetHashCode(Date obj) => obj.GetHashCode();
     }
 
     public int Next(Date input) =>

--- a/src/Verify/Counter_DateTime.cs
+++ b/src/Verify/Counter_DateTime.cs
@@ -2,7 +2,7 @@
 
 public partial class Counter
 {
-    Dictionary<DateTime, (int intValue, string stringValue)> dateTimeCache = new(new DateTimeComparer());
+    Dictionary<DateTime, (int intValue, string stringValue)> dateTimeCache;
     static Dictionary<DateTime, string> globalNamedDateTimes = [];
 
     class DateTimeComparer : IEqualityComparer<DateTime>
@@ -11,7 +11,7 @@ public partial class Counter
             x == y && x.Kind == y.Kind;
 
         public int GetHashCode(DateTime obj) =>
-            obj.GetHashCode() + (int) obj.Kind;
+            obj.GetHashCode() + (int)obj.Kind;
     }
 
     int currentDateTime;

--- a/src/Verify/Counter_DateTimeOffset.cs
+++ b/src/Verify/Counter_DateTimeOffset.cs
@@ -2,7 +2,7 @@
 
 public partial class Counter
 {
-    Dictionary<DateTimeOffset, (int intValue, string stringValue)> dateTimeOffsetCache = new(new DateTimeOffsetComparer());
+    Dictionary<DateTimeOffset, (int intValue, string stringValue)> dateTimeOffsetCache;
     static Dictionary<DateTimeOffset, string> globalNamedDateTimeOffsets = [];
 
     class DateTimeOffsetComparer :

--- a/src/Verify/Counter_Guid.cs
+++ b/src/Verify/Counter_Guid.cs
@@ -2,9 +2,16 @@
 
 public partial class Counter
 {
-    Dictionary<Guid, (int intValue, string stringValue)> guidCache = [];
+    Dictionary<Guid, (int intValue, string stringValue)> guidCache;
     static Dictionary<Guid, string> globalNamedGuids = [];
     int currentGuid;
+
+    class GuidComparer : IEqualityComparer<Guid>
+    {
+        public bool Equals(Guid x, Guid y) => x == y;
+
+        public int GetHashCode(Guid obj) => obj.GetHashCode() ;
+    }
 
     public int Next(Guid input) =>
         NextValue(input)

--- a/src/Verify/Counter_SettingsTask.cs
+++ b/src/Verify/Counter_SettingsTask.cs
@@ -19,14 +19,14 @@ public partial class SettingsTask
     }
 
     [Pure]
-    public SettingsTask ReplaceDateComparer(IEqualityComparer<Date> comparer)
+    public SettingsTask ReplaceScrubberDateComparer(IEqualityComparer<Date> comparer)
     {
         CurrentSettings.ReplaceScrubberDateComparer(comparer);
         return this;
     }
 
     [Pure]
-    public SettingsTask ReplaceTimeComparer(IEqualityComparer<Time> comparer)
+    public SettingsTask ReplaceScrubberTimeComparer(IEqualityComparer<Time> comparer)
     {
         CurrentSettings.ReplaceScrubberTimeComparer(comparer);
         return this;
@@ -56,21 +56,21 @@ public partial class SettingsTask
     }
 
     [Pure]
-    public SettingsTask ReplaceDateTimeComparer(IEqualityComparer<DateTime> comparer)
+    public SettingsTask ReplaceScrubberDateTimeComparer(IEqualityComparer<DateTime> comparer)
     {
         CurrentSettings.ReplaceScrubberDateTimeComparer(comparer);
         return this;
     }
 
     [Pure]
-    public SettingsTask ReplaceGuidComparer(IEqualityComparer<Guid> comparer)
+    public SettingsTask ReplaceScrubberGuidComparer(IEqualityComparer<Guid> comparer)
     {
         CurrentSettings.ReplaceScrubberGuidComparer(comparer);
         return this;
     }
 
     [Pure]
-    public SettingsTask ReplaceDateTimeOffsetComparer(IEqualityComparer<DateTimeOffset> comparer)
+    public SettingsTask ReplaceScrubberDateTimeOffsetComparer(IEqualityComparer<DateTimeOffset> comparer)
     {
         CurrentSettings.ReplaceScrubberDateTimeOffsetComparer(comparer);
         return this;

--- a/src/Verify/Counter_SettingsTask.cs
+++ b/src/Verify/Counter_SettingsTask.cs
@@ -18,6 +18,20 @@ public partial class SettingsTask
         return this;
     }
 
+    [Pure]
+    public SettingsTask ReplaceDateComparer(IEqualityComparer<Date> comparer)
+    {
+        CurrentSettings.ReplaceScrubberDateComparer(comparer);
+        return this;
+    }
+
+    [Pure]
+    public SettingsTask ReplaceTimeComparer(IEqualityComparer<Time> comparer)
+    {
+        CurrentSettings.ReplaceScrubberTimeComparer(comparer);
+        return this;
+    }
+
 #endif
 
     [Pure]
@@ -38,6 +52,27 @@ public partial class SettingsTask
     public SettingsTask AddNamedGuid(Guid value, string name)
     {
         CurrentSettings.AddNamedGuid(value, name);
+        return this;
+    }
+
+    [Pure]
+    public SettingsTask ReplaceDateTimeComparer(IEqualityComparer<DateTime> comparer)
+    {
+        CurrentSettings.ReplaceScrubberDateTimeComparer(comparer);
+        return this;
+    }
+
+    [Pure]
+    public SettingsTask ReplaceGuidComparer(IEqualityComparer<Guid> comparer)
+    {
+        CurrentSettings.ReplaceScrubberGuidComparer(comparer);
+        return this;
+    }
+
+    [Pure]
+    public SettingsTask ReplaceDateTimeOffsetComparer(IEqualityComparer<DateTimeOffset> comparer)
+    {
+        CurrentSettings.ReplaceScrubberDateTimeOffsetComparer(comparer);
         return this;
     }
 }

--- a/src/Verify/Counter_Time.cs
+++ b/src/Verify/Counter_Time.cs
@@ -3,9 +3,16 @@ namespace VerifyTests;
 
 public partial class Counter
 {
-    Dictionary<Time, (int intValue, string stringValue)> timeCache = [];
+    Dictionary<Time, (int intValue, string stringValue)> timeCache;
     static Dictionary<Time, string> globalNamedTimes = [];
     int currentTime;
+
+    class TimeComparer : IEqualityComparer<Time>
+    {
+        public bool Equals(Time x, Time y) => x == y;
+
+        public int GetHashCode(Time obj) => obj.GetHashCode() ;
+    }
 
     internal static void AddNamed(Time time, string name)
     {

--- a/src/Verify/Counter_VerifySettings.cs
+++ b/src/Verify/Counter_VerifySettings.cs
@@ -14,6 +14,24 @@ public partial class VerifySettings
     public void AddNamedTime(Time value, string name) =>
         namedTimes.Add(value, name);
 
+    internal IEqualityComparer<Date>? dateComparer;
+
+    public void ReplaceScrubberDateComparer(IEqualityComparer<Date> comparer)
+    {
+        ArgumentNullException.ThrowIfNull(comparer);
+
+        dateComparer = comparer;
+    }
+
+    internal IEqualityComparer<Time>? timeComparer;
+
+    public void ReplaceScrubberTimeComparer(IEqualityComparer<Time> comparer)
+    {
+        ArgumentNullException.ThrowIfNull(comparer);
+
+        timeComparer = comparer;
+    }
+
 #endif
 
     internal Dictionary<DateTime, string> namedDateTimes = [];
@@ -30,4 +48,31 @@ public partial class VerifySettings
 
     public void AddNamedDateTimeOffset(DateTimeOffset value, string name) =>
         namedDateTimeOffsets.Add(value, name);
+
+    internal IEqualityComparer<DateTime>? dateTimeComparer;
+
+    public void ReplaceScrubberDateTimeComparer(IEqualityComparer<DateTime> comparer)
+    {
+        ArgumentNullException.ThrowIfNull(comparer);
+
+        dateTimeComparer = comparer;
+    }
+
+    internal IEqualityComparer<Guid>? guidComparer;
+
+    public void ReplaceScrubberGuidComparer(IEqualityComparer<Guid> comparer)
+    {
+        ArgumentNullException.ThrowIfNull(comparer);
+
+        guidComparer = comparer;
+    }
+
+    internal IEqualityComparer<DateTimeOffset>? dateTimeOffsetComparer;
+
+    public void ReplaceScrubberDateTimeOffsetComparer(IEqualityComparer<DateTimeOffset> comparer)
+    {
+        ArgumentNullException.ThrowIfNull(comparer);
+
+        dateTimeOffsetComparer = comparer;
+    }
 }

--- a/src/Verify/Verifier/InnerVerifier.cs
+++ b/src/Verify/Verifier/InnerVerifier.cs
@@ -107,7 +107,12 @@ public partial class InnerVerifier :
 #endif
             settings.namedDateTimes,
             settings.namedGuids,
-            settings.namedDateTimeOffsets
+            settings.namedDateTimeOffsets,
+            settings.dateComparer,
+            settings.timeComparer,
+            settings.dateTimeComparer,
+            settings.guidComparer,
+            settings.dateTimeOffsetComparer
         );
 
     void InitForDirectoryConvention(Namer namer, string typeAndMethod, string parameters)

--- a/src/Verify/Verifier/InnerVerifier.cs
+++ b/src/Verify/Verifier/InnerVerifier.cs
@@ -108,8 +108,10 @@ public partial class InnerVerifier :
             settings.namedDateTimes,
             settings.namedGuids,
             settings.namedDateTimeOffsets,
+#if NET6_0_OR_GREATER
             settings.dateComparer,
             settings.timeComparer,
+#endif
             settings.dateTimeComparer,
             settings.guidComparer,
             settings.dateTimeOffsetComparer

--- a/src/Verify/VerifySettings.cs
+++ b/src/Verify/VerifySettings.cs
@@ -47,10 +47,16 @@ public partial class VerifySettings
 #if NET6_0_OR_GREATER
         namedDates = new(settings.namedDates);
         namedTimes = new(settings.namedTimes);
+        dateComparer = settings.dateComparer;
+        timeComparer = settings.timeComparer;
 #endif
         namedGuids = new(settings.namedGuids);
         namedDateTimes = new(settings.namedDateTimes);
         namedDateTimeOffsets = new(settings.namedDateTimeOffsets);
+        dateTimeComparer = settings.dateTimeComparer;
+        guidComparer = settings.guidComparer;
+        dateTimeOffsetComparer = settings.dateTimeOffsetComparer;
+
         foreach (var append in settings.Appends)
         {
             if (append.Data is ICloneable cloneable)


### PR DESCRIPTION
Ability to add custom comparers to Counter

```csharp
private class StubGuidComparer : IEqualityComparer<Guid>
    {
        public bool Equals(Guid x, Guid y) => true;

        public int GetHashCode(Guid obj) => 1;
    }

    [Fact]
    public async Task ShouldInjectCustomGuidComparer()
    {
        var obj = new
        {
            Item1 = Guid.NewGuid(),
            Item2 = Guid.NewGuid(),
            Item3 = Guid.NewGuid()
        };

        var settings = new VerifySettings();
        settings.ReplaceScrubberGuidComparer(new StubGuidComparer());
        await Verify(obj, settings: settings);
    }
```

This test case will produce the following .verified.txt file

```
{
  Item1: Guid_1,
  Item2: Guid_1,
  Item3: Guid_1
}
```