### PR TITLE
Move Expecto caveats under Expecto heading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -288,6 +288,14 @@ let tests =
 <!-- endSnippet -->
 
 
+#### Caveats
+
+Due to the nature of the Expecto implementation, the following APIs in Verify are not supported.
+
+* `settings.UseParameters()`
+* `settings.UseTextForParameters()`
+
+
 ### TUnit
 
 Support for [TUnit](https://github.com/thomhurst/TUnit)
@@ -307,14 +315,6 @@ public class Sample
 ```
 <sup><a href='/src/Verify.TUnit.Tests/Snippets/Sample.cs#L1-L13' title='Snippet source file'>snippet source</a> | <a href='#snippet-SampleTestTUnit' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
-
-
-#### Caveats
-
-Due to the nature of the Expecto implementation, the following APIs in Verify are not supported.
-
-* `settings.UseParameters()`
-* `settings.UseTextForParameters()`
 
 
 ### MSTest

--- a/readme.source.md
+++ b/readme.source.md
@@ -121,19 +121,19 @@ Support for [Expecto](https://github.com/haf/expecto)
 snippet: SampleTestExpecto
 
 
-### TUnit
-
-Support for [TUnit](https://github.com/thomhurst/TUnit)
-
-snippet: SampleTestTUnit
-
-
 #### Caveats
 
 Due to the nature of the Expecto implementation, the following APIs in Verify are not supported.
 
 * `settings.UseParameters()`
 * `settings.UseTextForParameters()`
+
+
+### TUnit
+
+Support for [TUnit](https://github.com/thomhurst/TUnit)
+
+snippet: SampleTestTUnit
 
 
 ### MSTest


### PR DESCRIPTION
Just fixing some positioning. The expecto caveats were under TUnit instead of Expecto.