### PR TITLE
Fix StaticAutoVerifyDelegate example

### DIFF
--- a/docs/mdsource/verify-options.source.md
+++ b/docs/mdsource/verify-options.source.md
@@ -36,7 +36,7 @@ snippet: StaticAutoVerify
 
 Or with a delegate:
 
-snippet: StaticAutoVerify
+snippet: StaticAutoVerifyDelegate
 
 
 ## OnHandlers


### PR DESCRIPTION
The globally settings delegate is using the wrong example: https://github.com/VerifyTests/Verify/blob/main/docs/verify-options.md#globally