### PR TITLE
Builder Pattern - Allow chaining settings configuration calls

### DIFF
--- a/src/Verify.Expecto.FSharpTests/Tests.fs
+++ b/src/Verify.Expecto.FSharpTests/Tests.fs
@@ -18,7 +18,7 @@ let tests =
 let uniqueTests =
     testTask "unique" {
         let settings = VerifySettings()
-        settings.UniqueForRuntime()
+                           .UniqueForRuntime()
         do! Verifier.Verify("unique", "value", settings)
     }
 // end-snippet
@@ -27,7 +27,7 @@ let uniqueTests =
 let typeNameTests =
     testTask "typeNameTests" {
         let settings = VerifySettings()
-        settings.UseTypeName("CustomTypeName")
+                           .UseTypeName("CustomTypeName")
         do! Verifier.Verify("typeNameTests", "Value", settings)
     }
 
@@ -35,6 +35,6 @@ let typeNameTests =
 let methodNameTests =
     testTask "methodNameTests" {
         let settings = VerifySettings()
-        settings.UseMethodName("CustomMethodName")
+                           .UseMethodName("CustomMethodName")
         do! Verifier.Verify("methodNameTests", "Value", settings)
     }

--- a/src/Verify/Callbacks/VerifySettings.cs
+++ b/src/Verify/Callbacks/VerifySettings.cs
@@ -4,11 +4,17 @@ public partial class VerifySettings
 {
     FirstVerify? handleOnFirstVerify;
 
-    public void OnFirstVerify(FirstVerify firstVerify) =>
+    public VerifySettings OnFirstVerify(FirstVerify firstVerify)
+    {
         handleOnFirstVerify += firstVerify;
+        return this;
+    }
 
-    public void OnDelete(VerifyDelete verifyDelete) =>
+    public VerifySettings OnDelete(VerifyDelete verifyDelete)
+    {
         handleOnVerifyDelete += verifyDelete;
+        return this;
+    }
 
     VerifyDelete? handleOnVerifyDelete;
 
@@ -44,13 +50,17 @@ public partial class VerifySettings
         await VerifierSettings.RunOnVerifyMismatch(item, message, autoVerify);
     }
 
-    public void OnVerifyMismatch(VerifyMismatch verifyMismatch) =>
+    public VerifySettings OnVerifyMismatch(VerifyMismatch verifyMismatch)
+    {
         handleOnVerifyMismatch += verifyMismatch;
+        return this;
+    }
 
-    public void OnVerify(Action before, Action after)
+    public VerifySettings OnVerify(Action before, Action after)
     {
         beforeVerify += before;
         afterVerify += after;
+        return this;
     }
 
     Action? beforeVerify;

--- a/src/Verify/Compare/VerifySettings.cs
+++ b/src/Verify/Compare/VerifySettings.cs
@@ -5,11 +5,17 @@ public partial class VerifySettings
     StreamCompare? streamComparer;
     StringCompare? stringComparer;
 
-    public void UseStreamComparer(StreamCompare compare) =>
+    public VerifySettings UseStreamComparer(StreamCompare compare)
+    {
         streamComparer = compare;
+        return this;
+    }
 
-    public void UseStringComparer(StringCompare compare) =>
+    public VerifySettings UseStringComparer(StringCompare compare)
+    {
         stringComparer = compare;
+        return this;
+    }
 
     // Dont use this.extension since a converter may have
     // changed the extension for the current compare operation

--- a/src/Verify/Counter_VerifySettings.cs
+++ b/src/Verify/Counter_VerifySettings.cs
@@ -6,28 +6,43 @@ public partial class VerifySettings
 
     internal Dictionary<Date, string> namedDates = [];
 
-    public void AddNamedDate(Date value, string name) =>
+    public VerifySettings AddNamedDate(Date value, string name)
+    {
         namedDates.Add(value, name);
+        return this;
+    }
 
     internal Dictionary<Time, string> namedTimes = [];
 
-    public void AddNamedTime(Time value, string name) =>
+    public VerifySettings AddNamedTime(Time value, string name)
+    {
         namedTimes.Add(value, name);
+        return this;
+    }
 
 #endif
 
     internal Dictionary<DateTime, string> namedDateTimes = [];
 
-    public void AddNamedDateTime(DateTime value, string name) =>
+    public VerifySettings AddNamedDateTime(DateTime value, string name)
+    {
         namedDateTimes.Add(value, name);
+        return this;
+    }
 
     internal Dictionary<Guid, string> namedGuids = [];
 
-    public void AddNamedGuid(Guid value, string name) =>
+    public VerifySettings AddNamedGuid(Guid value, string name)
+    {
         namedGuids.Add(value, name);
+        return this;
+    }
 
     internal Dictionary<DateTimeOffset, string> namedDateTimeOffsets = [];
 
-    public void AddNamedDateTimeOffset(DateTimeOffset value, string name) =>
+    public VerifySettings AddNamedDateTimeOffset(DateTimeOffset value, string name)
+    {
         namedDateTimeOffsets.Add(value, name);
+        return this;
+    }
 }

--- a/src/Verify/DiffTool/VerifySettings.cs
+++ b/src/Verify/DiffTool/VerifySettings.cs
@@ -7,6 +7,9 @@ public partial class VerifySettings
     /// <summary>
     /// Disable using a diff tool for this test
     /// </summary>
-    public void DisableDiff() =>
+    public VerifySettings DisableDiff()
+    {
         diffEnabled = false;
+        return this;
+    }
 }

--- a/src/Verify/Naming/VerifySettings.cs
+++ b/src/Verify/Naming/VerifySettings.cs
@@ -8,58 +8,73 @@ public partial class VerifySettings
     /// Use the current runtime to make the test results unique.
     /// Used when a test produces different results based on runtime.
     /// </summary>
-    public void UniqueForRuntime() =>
+    public VerifySettings UniqueForRuntime()
+    {
         Namer.UniqueForRuntime = true;
+        return this;
+    }
 
     /// <summary>
     /// Use the current test assembly TargetFrameworkAttribute to make the test results unique.
     /// Used when a test produces different results based on TargetFramework.
     /// </summary>
-    public void UniqueForTargetFramework() =>
+    public VerifySettings UniqueForTargetFramework()
+    {
         Namer.UniqueForTargetFramework = true;
+        return this;
+    }
 
     /// <summary>
     /// Use the current test assembly TargetFrameworkAttribute name and version to make the test results unique.
     /// Used when a test produces different results based on TargetFramework and TargetFramework version.
     /// </summary>
-    public void UniqueForTargetFrameworkAndVersion() =>
+    public VerifySettings UniqueForTargetFrameworkAndVersion()
+    {
         Namer.UniqueForTargetFrameworkAndVersion = true;
+        return this;
+    }
 
     /// <summary>
     /// Use the current test assembly configuration (debug/release) to make the test results unique.
     /// Used when a test produces different results based on assembly configuration.
     /// </summary>
-    public void UniqueForAssemblyConfiguration() =>
+    public VerifySettings UniqueForAssemblyConfiguration()
+    {
         Namer.UniqueForAssemblyConfiguration = true;
+        return this;
+    }
 
     /// <summary>
     /// Use <paramref name="assembly" /> TargetFrameworkAttribute to make the test results unique.
     /// Used when a test produces different results based on TargetFramework.
     /// </summary>
-    public void UniqueForTargetFramework(Assembly assembly)
+    public VerifySettings UniqueForTargetFramework(Assembly assembly)
     {
         Namer.UniqueForTargetFramework = true;
         Namer.SetUniqueForAssemblyFrameworkName(assembly);
+        return this;
     }
 
     /// <summary>
     /// Use the <paramref name="assembly" /> TargetFrameworkAttribute name and version to make the test results unique.
     /// Used when a test produces different results based on TargetFramework and TargetFramework version.
     /// </summary>
-    public void UniqueForTargetFrameworkAndVersion(Assembly assembly)
+    public VerifySettings UniqueForTargetFrameworkAndVersion(Assembly assembly)
     {
         Namer.UniqueForTargetFrameworkAndVersion = true;
         Namer.SetUniqueForAssemblyFrameworkName(assembly);
+        return this;
     }
 
     /// <summary>
     /// Use the <paramref name="assembly" /> configuration (debug/release) to make the test results unique.
     /// Used when a test produces different results based on assembly configuration.
     /// </summary>
-    public void UniqueForAssemblyConfiguration(Assembly assembly)
+    public VerifySettings UniqueForAssemblyConfiguration(Assembly assembly)
     {
         Namer.UniqueForAssemblyConfiguration = true;
         Namer.SetUniqueForAssemblyConfiguration(assembly);
+        return this;
     }
 
     public string? Directory { get; internal set; }
@@ -67,10 +82,11 @@ public partial class VerifySettings
     /// <summary>
     /// Use a custom directory for the test results.
     /// </summary>
-    public void UseDirectory(string directory)
+    public VerifySettings UseDirectory(string directory)
     {
         Guards.BadDirectoryName(directory);
         Directory = directory;
+        return this;
     }
 
     internal string? typeName;
@@ -80,12 +96,13 @@ public partial class VerifySettings
     /// Where the file format is `{CurrentDirectory}/{TestClassName}.{TestMethodName}_{Parameters}_{UniqueFor1}_{UniqueFor2}_{UniqueForX}.verified.{extension}`.
     /// </summary>
     /// <remarks>Not compatible with <see cref="UseFileName" />.</remarks>
-    public void UseTypeName(string name)
+    public VerifySettings UseTypeName(string name)
     {
         Guards.BadFileName(name);
         ThrowIfFileNameDefined();
 
         typeName = name;
+        return this;
     }
 
     internal string? methodName;
@@ -95,12 +112,13 @@ public partial class VerifySettings
     /// Where the file format is `{CurrentDirectory}/{TestClassName}.{TestMethodName}_{Parameters}_{UniqueFor1}_{UniqueFor2}_{UniqueForX}.verified.{extension}`.
     /// </summary>
     /// <remarks>Not compatible with <see cref="UseFileName" />.</remarks>
-    public void UseMethodName(string name)
+    public VerifySettings UseMethodName(string name)
     {
         Guards.BadFileName(name);
         ThrowIfFileNameDefined();
 
         methodName = name;
+        return this;
     }
 
     void ThrowIfFileNameDefined([CallerMemberName] string caller = "")
@@ -119,12 +137,13 @@ public partial class VerifySettings
     /// Where the new file format is `{CurrentDirectory}/{FileName}_{UniqueFor1}_{UniqueFor2}_{UniqueForX}.verified.{extension}`.
     /// </summary>
     /// <remarks>Not compatible with <see cref="UseTypeName" />, <see cref="UseMethodName" />, or <see cref="UseParameters" />.</remarks>
-    public void UseFileName(string fileName)
+    public VerifySettings UseFileName(string fileName)
     {
         Guards.BadFileName(fileName);
         ThrowIfMethodOrTypeNameDefined();
 
         this.fileName = fileName;
+        return this;
     }
 
     void ThrowIfMethodOrTypeNameDefined()
@@ -142,51 +161,72 @@ public partial class VerifySettings
     /// Use a directory for the test results.
     /// Where the file format is `{CurrentDirectory}/{TestClassName}.{TestMethodName}_{Parameters}_{UniqueFor1}_{UniqueFor2}_{UniqueForX}/{targetName}.verified.{extension}`.
     /// </summary>
-    public void UseUniqueDirectory() =>
+    public VerifySettings UseUniqueDirectory()
+    {
         useUniqueDirectory = true;
+        return this;
+    }
 
     /// <summary>
     /// Use the current runtime and runtime version to make the test results unique.
     /// Used when a test produces different results based on runtime and runtime version.
     /// </summary>
-    public void UniqueForRuntimeAndVersion() =>
+    public VerifySettings UniqueForRuntimeAndVersion()
+    {
         Namer.UniqueForRuntimeAndVersion = true;
+        return this;
+    }
 
     /// <summary>
     /// Use the current processor architecture (x86/x64/arm/arm64) to make the test results unique.
     /// Used when a test produces different results based on processor architecture.
     /// </summary>
-    public void UniqueForArchitecture() =>
+    public VerifySettings UniqueForArchitecture()
+    {
         Namer.UniqueForArchitecture = true;
+        return this;
+    }
 
     /// <summary>
     /// Use the operating system family (Linux/Windows/OSX) to make the test results unique.
     /// Used when a test produces different results based on operating system family.
     /// </summary>
-    public void UniqueForOSPlatform() =>
+    public VerifySettings UniqueForOSPlatform()
+    {
         Namer.UniqueForOSPlatform = true;
+        return this;
+    }
 
     internal bool UniquePrefixDisabled;
 
     /// <summary>
     /// Allow multiple tests to map to the same snapshot file prefix.
     /// </summary>
-    public void DisableRequireUniquePrefix() =>
+    public VerifySettings DisableRequireUniquePrefix()
+    {
         UniquePrefixDisabled = true;
+        return this;
+    }
 
     /// <summary>
     /// Use the current runtime to make the test results unique.
     /// Used when a test produces different results based on runtime.
     /// </summary>
-    public void UseSplitModeForUniqueDirectory() =>
+    public VerifySettings UseSplitModeForUniqueDirectory()
+    {
         UseUniqueDirectorySplitMode = true;
+        return this;
+    }
 
     /// <summary>
     /// Dont use the current runtime to make the test results unique.
     /// Overrides <see cref="VerifierSettings.UseSplitModeForUniqueDirectory" />.
     /// </summary>
-    public void DontUseSplitModeForUniqueDirectory() =>
+    public VerifySettings DontUseSplitModeForUniqueDirectory()
+    {
         UseUniqueDirectorySplitMode = false;
+        return this;
+    }
 
     internal bool? UseUniqueDirectorySplitMode;
 }

--- a/src/Verify/Naming/VerifySettings_Parameter.cs
+++ b/src/Verify/Naming/VerifySettings_Parameter.cs
@@ -19,7 +19,7 @@ public partial class VerifySettings
     public bool HasParameters => parameters != null;
 
     /// <inheritdoc cref="UseParameters(object?[])"/>
-    public void UseParameters<T>(T[] parameters) =>
+    public VerifySettings UseParameters<T>(T[] parameters) =>
         UseParameters(
             new object?[]
             {
@@ -27,7 +27,7 @@ public partial class VerifySettings
             });
 
     /// <inheritdoc cref="UseParameters(object?[])"/>
-    public void UseParameters<T>(T parameter) =>
+    public VerifySettings UseParameters<T>(T parameter) =>
         UseParameters(
             new object?[]
             {
@@ -52,17 +52,21 @@ public partial class VerifySettings
     /// In the scenarios where parameters are not automatically detected, an exception will be thrown instructing the potential need for <see cref="UseParameters" />
     /// Not compatible with <see cref="UseTextForParameters" />.
     /// </summary>
-    public void UseParameters(params object?[] parameters)
+    public VerifySettings UseParameters(params object?[] parameters)
     {
         Guard.NotNullOrEmpty(parameters);
         ThrowIfFileNameDefined();
         ThrowIfParametersTextDefined();
         this.parameters = parameters;
+        return this;
     }
 
     [Experimental("VerifySetParameters")]
-    public void SetParameters(object?[] parameters) =>
+    public VerifySettings SetParameters(object?[] parameters)
+    {
         this.parameters = parameters;
+        return this;
+    }
 
     void ThrowIfParametersTextDefined([CallerMemberName] string caller = "")
     {
@@ -79,8 +83,11 @@ public partial class VerifySettings
     /// Note that UseParameters has still been called for test frameworks that don't support automatic parameter detection and the 'received' files still contains the parameters.
     /// </summary>
     /// <param name="parameterNames">The names of the parameters to be ignored. When passing an empty list all parameters will be ignored.</param>
-    public void IgnoreParameters(params string[] parameterNames) =>
+    public VerifySettings IgnoreParameters(params string[] parameterNames)
+    {
         ignoredParameters = parameterNames.ToHashSet();
+        return this;
+    }
 
     internal bool ignoreParametersForVerified;
 
@@ -89,7 +96,7 @@ public partial class VerifySettings
     /// Note that the 'received' files still contain the parameters.
     /// </summary>
     /// <param name="parameters">The parameters as you would have passed them to the UseParameters function.</param>
-    public void IgnoreParametersForVerified(params object?[] parameters)
+    public VerifySettings IgnoreParametersForVerified(params object?[] parameters)
     {
         if (parameters.Length > 0)
         {
@@ -97,6 +104,7 @@ public partial class VerifySettings
         }
 
         ignoreParametersForVerified = true;
+        return this;
     }
 
     internal bool hashParameters;
@@ -105,10 +113,11 @@ public partial class VerifySettings
     /// Hash parameters together and pass to <see cref="UseTextForParameters" />.
     /// Used to get a deterministic file name while avoiding long paths.
     /// </summary>
-    public void HashParameters()
+    public VerifySettings HashParameters()
     {
         ThrowIfFileNameDefined();
         ThrowIfParametersTextDefined();
         hashParameters = true;
+        return this;
     }
 }

--- a/src/Verify/Serialization/Scrubbers/VerifySettings_ExtensionMappedInstanceScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifySettings_ExtensionMappedInstanceScrubbers.cs
@@ -7,13 +7,13 @@ public partial class VerifySettings
     /// <summary>
     /// Modify the resulting test content using custom code.
     /// </summary>
-    public void AddScrubber(string extension, Action<StringBuilder> scrubber, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings AddScrubber(string extension, Action<StringBuilder> scrubber, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(extension, (builder, _) => scrubber(builder), location);
 
     /// <summary>
     /// Modify the resulting test content using custom code.
     /// </summary>
-    public void AddScrubber(string extension, Action<StringBuilder, Counter> scrubber, ScrubberLocation location = ScrubberLocation.First)
+    public VerifySettings AddScrubber(string extension, Action<StringBuilder, Counter> scrubber, ScrubberLocation location = ScrubberLocation.First)
     {
         if (!ExtensionMappedInstanceScrubbers.TryGetValue(extension, out var values))
         {
@@ -29,60 +29,62 @@ public partial class VerifySettings
                 values.Add(scrubber);
                 break;
         }
+
+        return this;
     }
 
     /// <summary>
     /// Remove the <see cref="Environment.MachineName" /> from the test results.
     /// </summary>
-    public void ScrubMachineName(string extension, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubMachineName(string extension, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(extension, Scrubbers.ScrubMachineName, location);
 
     /// <summary>
     /// Remove the <see cref="Environment.UserName" /> from the test results.
     /// </summary>
-    public void ScrubUserName(string extension, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubUserName(string extension, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(extension, Scrubbers.ScrubUserName, location);
 
     /// <summary>
     /// Remove any lines containing any of <paramref name="stringToMatch" /> from the test results.
     /// </summary>
-    public void ScrubLinesContaining(string extension, StringComparison comparison, params string[] stringToMatch) =>
+    public VerifySettings ScrubLinesContaining(string extension, StringComparison comparison, params string[] stringToMatch) =>
         ScrubLinesContaining(extension, comparison, ScrubberLocation.First, stringToMatch);
 
     /// <summary>
     /// Remove any lines containing any of <paramref name="stringToMatch" /> from the test results.
     /// </summary>
-    public void ScrubLinesContaining(string extension, StringComparison comparison, ScrubberLocation location, params string[] stringToMatch) =>
+    public VerifySettings ScrubLinesContaining(string extension, StringComparison comparison, ScrubberLocation location, params string[] stringToMatch) =>
         AddScrubber(extension, _ => _.RemoveLinesContaining(comparison, stringToMatch), location);
 
     /// <summary>
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
-    public void ScrubInlineGuids(string extension, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubInlineGuids(string extension, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(extension, GuidScrubber.ReplaceGuids, location);
 
     /// <summary>
     /// Remove any lines matching <paramref name="removeLine" /> from the test results.
     /// </summary>
-    public void ScrubLines(string extension, Func<string, bool> removeLine, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubLines(string extension, Func<string, bool> removeLine, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(extension, _ => _.FilterLines(removeLine), location);
 
     /// <summary>
     /// Scrub lines with an optional replace.
     /// <paramref name="replaceLine" /> can return the input to ignore the line, or return a different string to replace it.
     /// </summary>
-    public void ScrubLinesWithReplace(string extension, Func<string, string?> replaceLine, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubLinesWithReplace(string extension, Func<string, string?> replaceLine, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(extension, _ => _.ReplaceLines(replaceLine), location);
 
     /// <summary>
     /// Remove any lines containing only whitespace from the test results.
     /// </summary>
-    public void ScrubEmptyLines(string extension, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubEmptyLines(string extension, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(extension, _ => _.RemoveEmptyLines(), location);
 
     /// <summary>
     /// Remove any lines containing any of <paramref name="stringToMatch" /> from the test results.
     /// </summary>
-    public void ScrubLinesContaining(string extension, ScrubberLocation location = ScrubberLocation.First, params string[] stringToMatch) =>
+    public VerifySettings ScrubLinesContaining(string extension, ScrubberLocation location = ScrubberLocation.First, params string[] stringToMatch) =>
         ScrubLinesContaining(extension, StringComparison.OrdinalIgnoreCase, location, stringToMatch);
 }

--- a/src/Verify/Serialization/Scrubbers/VerifySettings_InstanceScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifySettings_InstanceScrubbers.cs
@@ -7,7 +7,7 @@ public partial class VerifySettings
     /// <summary>
     /// Remove the <see cref="Environment.MachineName" /> from the test results.
     /// </summary>
-    public void ScrubMachineName(ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubMachineName(ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(Scrubbers.ScrubMachineName, location);
 
     /// <summary>
@@ -19,13 +19,13 @@ public partial class VerifySettings
     /// <summary>
     /// Modify the resulting test content using custom code.
     /// </summary>
-    public void AddScrubber(Action<StringBuilder> scrubber, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings AddScrubber(Action<StringBuilder> scrubber, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber((builder, _) => scrubber(builder), location);
 
     /// <summary>
     /// Modify the resulting test content using custom code.
     /// </summary>
-    public void AddScrubber(Action<StringBuilder, Counter> scrubber, ScrubberLocation location = ScrubberLocation.First)
+    public VerifySettings AddScrubber(Action<StringBuilder, Counter> scrubber, ScrubberLocation location = ScrubberLocation.First)
     {
         switch (location)
         {
@@ -36,30 +36,32 @@ public partial class VerifySettings
                 InstanceScrubbers.Add(scrubber);
                 break;
         }
+
+        return this;
     }
 
     /// <summary>
     /// Remove any lines containing any of <paramref name="stringToMatch" /> from the test results.
     /// </summary>
-    public void ScrubLinesContaining(StringComparison comparison, params string[] stringToMatch) =>
+    public VerifySettings ScrubLinesContaining(StringComparison comparison, params string[] stringToMatch) =>
         ScrubLinesContaining(comparison, ScrubberLocation.First, stringToMatch);
 
     /// <summary>
     /// Remove any lines containing any of <paramref name="stringToMatch" /> from the test results.
     /// </summary>
-    public void ScrubLinesContaining(StringComparison comparison, ScrubberLocation location, params string[] stringToMatch) =>
+    public VerifySettings ScrubLinesContaining(StringComparison comparison, ScrubberLocation location, params string[] stringToMatch) =>
         AddScrubber(_ => _.RemoveLinesContaining(comparison, stringToMatch), location);
 
     /// <summary>
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
-    public void ScrubInlineGuids(ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubInlineGuids(ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(GuidScrubber.ReplaceGuids, location);
 
     /// <summary>
     /// Replace inline <see cref="DateTime" />s with a placeholder.
     /// </summary>
-    public void ScrubInlineDateTimes(
+    public VerifySettings ScrubInlineDateTimes(
         [StringSyntax(StringSyntaxAttribute.DateTimeFormat)] string format,
         Culture? culture = null,
         ScrubberLocation location = ScrubberLocation.First) =>
@@ -70,7 +72,7 @@ public partial class VerifySettings
     /// <summary>
     /// Replace inline <see cref="DateTime" />s with a placeholder.
     /// </summary>
-    public void ScrubInlineDateTimeOffsets(
+    public VerifySettings ScrubInlineDateTimeOffsets(
         [StringSyntax(StringSyntaxAttribute.DateTimeFormat)] string format,
         Culture? culture = null,
         ScrubberLocation location = ScrubberLocation.First) =>
@@ -83,7 +85,7 @@ public partial class VerifySettings
     /// <summary>
     /// Replace inline <see cref="Date" />s with a placeholder.
     /// </summary>
-    public void ScrubInlineDates(
+    public VerifySettings ScrubInlineDates(
         [StringSyntax(StringSyntaxAttribute.DateOnlyFormat)] string format,
         Culture? culture = null,
         ScrubberLocation location = ScrubberLocation.First) =>
@@ -96,31 +98,31 @@ public partial class VerifySettings
     /// <summary>
     /// Remove any lines matching <paramref name="removeLine" /> from the test results.
     /// </summary>
-    public void ScrubLines(Func<string, bool> removeLine, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubLines(Func<string, bool> removeLine, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(_ => _.FilterLines(removeLine), location);
 
     /// <summary>
     /// Scrub lines with an optional replace.
     /// <paramref name="replaceLine" /> can return the input to ignore the line, or return a different string to replace it.
     /// </summary>
-    public void ScrubLinesWithReplace(Func<string, string?> replaceLine, ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubLinesWithReplace(Func<string, string?> replaceLine, ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(_ => _.ReplaceLines(replaceLine), location);
 
     /// <summary>
     /// Remove any lines containing only whitespace from the test results.
     /// </summary>
-    public void ScrubEmptyLines(ScrubberLocation location = ScrubberLocation.First) =>
+    public VerifySettings ScrubEmptyLines(ScrubberLocation location = ScrubberLocation.First) =>
         AddScrubber(_ => _.RemoveEmptyLines(), location);
 
     /// <summary>
     /// Remove any lines containing any of <paramref name="stringToMatch" /> from the test results.
     /// </summary>
-    public void ScrubLinesContaining(params string[] stringToMatch) =>
+    public VerifySettings ScrubLinesContaining(params string[] stringToMatch) =>
         ScrubLinesContaining(ScrubberLocation.First, stringToMatch);
 
     /// <summary>
     /// Remove any lines containing any of <paramref name="stringToMatch" /> from the test results.
     /// </summary>
-    public void ScrubLinesContaining(ScrubberLocation location = ScrubberLocation.First, params string[] stringToMatch) =>
+    public VerifySettings ScrubLinesContaining(ScrubberLocation location = ScrubberLocation.First, params string[] stringToMatch) =>
         ScrubLinesContaining(StringComparison.OrdinalIgnoreCase, location, stringToMatch);
 }

--- a/src/Verify/Serialization/SerializationSettings_IgnoreByName.cs
+++ b/src/Verify/Serialization/SerializationSettings_IgnoreByName.cs
@@ -4,37 +4,41 @@ partial class SerializationSettings
 {
     Dictionary<string, ScrubOrIgnore?> ignoredByNameMembers = [];
 
-    public void IgnoreStackTrace() =>
+    public SerializationSettings IgnoreStackTrace() =>
         IgnoreMember("StackTrace");
 
-    public void IgnoreMember(string name)
+    public SerializationSettings IgnoreMember(string name)
     {
         Guard.NotNullOrEmpty(name);
         ignoredByNameMembers[name] = ScrubOrIgnore.Ignore;
+        return this;
     }
 
-    public void ScrubMember(string name)
+    public SerializationSettings ScrubMember(string name)
     {
         Guard.NotNullOrEmpty(name);
         ignoredByNameMembers[name] = ScrubOrIgnore.Scrub;
+        return this;
     }
 
-    public void IgnoreMembers(params string[] names)
+    public SerializationSettings IgnoreMembers(params string[] names)
     {
         Guard.NotNullOrEmpty(names);
         foreach (var name in names)
         {
             IgnoreMember(name);
         }
+        return this;
     }
 
-    public void ScrubMembers(params string[] names)
+    public SerializationSettings ScrubMembers(params string[] names)
     {
         Guard.NotNullOrEmpty(names);
         foreach (var name in names)
         {
             ScrubMember(name);
         }
+        return this;
     }
 
     internal bool ShouldIgnoreByName(string name)

--- a/src/Verify/Serialization/VerifySettings.cs
+++ b/src/Verify/Serialization/VerifySettings.cs
@@ -18,8 +18,11 @@ public partial class VerifySettings
 
     internal JsonSerializer Serializer => serialization.Serializer;
 
-    public void UseStrictJson() =>
+    public VerifySettings UseStrictJson()
+    {
         strictJson = true;
+        return this;
+    }
 
     public bool StrictJson => VerifierSettings.StrictJson ||
                               strictJson;
@@ -31,36 +34,45 @@ public partial class VerifySettings
     /// <summary>
     /// Append a key-value pair to the serialized target.
     /// </summary>
-    public void AppendValue(string name, object data) =>
+    public VerifySettings AppendValue(string name, object data)
+    {
         Appends.Add(new(name, data));
-
-    /// <summary>
-    /// Append key-value pairs to the serialized target.
-    /// </summary>
-    public void AppendValues(IEnumerable<KeyValuePair<string, object>> values)
-    {
-        foreach (var pair in values)
-        {
-            AppendValue(pair.Key, pair.Value);
-        }
+        return this;
     }
 
     /// <summary>
     /// Append key-value pairs to the serialized target.
     /// </summary>
-    public void AppendValues(params KeyValuePair<string, object>[] values)
+    public VerifySettings AppendValues(IEnumerable<KeyValuePair<string, object>> values)
     {
         foreach (var pair in values)
         {
             AppendValue(pair.Key, pair.Value);
         }
+
+        return this;
     }
 
-    public void AddExtraSettings(Action<JsonSerializerSettings> action)
+    /// <summary>
+    /// Append key-value pairs to the serialized target.
+    /// </summary>
+    public VerifySettings AppendValues(params KeyValuePair<string, object>[] values)
+    {
+        foreach (var pair in values)
+        {
+            AppendValue(pair.Key, pair.Value);
+        }
+
+        return this;
+    }
+
+    public VerifySettings AddExtraSettings(Action<JsonSerializerSettings> action)
     {
         CloneSettings();
 
         serialization.AddExtraSettings(action);
+
+        return this;
     }
 
     bool dateCountingEnable = true;
@@ -78,6 +90,9 @@ public partial class VerifySettings
         }
     }
 
-    public void DisableDateCounting() =>
+    public VerifySettings DisableDateCounting()
+    {
         dateCountingEnable = false;
+        return this;
+    }
 }

--- a/src/Verify/Serialization/VerifySettings_SerializationMaps.cs
+++ b/src/Verify/Serialization/VerifySettings_SerializationMaps.cs
@@ -2,240 +2,277 @@
 
 public partial class VerifySettings
 {
-    public void DontScrubGuids()
+    public VerifySettings DontScrubGuids()
     {
         CloneSettings();
         serialization.DontScrubGuids();
+        return this;
     }
 
-    public void DontScrubDateTimes()
+    public VerifySettings DontScrubDateTimes()
     {
         CloneSettings();
         serialization.DontScrubDateTimes();
+        return this;
     }
 
-    public void DontSortDictionaries()
+    public VerifySettings DontSortDictionaries()
     {
         CloneSettings();
         serialization.DontSortDictionaries();
+        return this;
     }
 
-    public void IgnoreStackTrace()
+    public VerifySettings IgnoreStackTrace()
     {
         CloneSettings();
         serialization.IgnoreMember("StackTrace");
+        return this;
     }
 
-    public void IncludeObsoletes()
+    public VerifySettings IncludeObsoletes()
     {
         CloneSettings();
         serialization.IncludeObsoletes();
+        return this;
     }
 
-    public void DontIgnoreEmptyCollections()
+    public VerifySettings DontIgnoreEmptyCollections()
     {
         CloneSettings();
         serialization.DontIgnoreEmptyCollections();
+        return this;
     }
 
-    public void IgnoreMembers<T>(params Expression<Func<T, object?>>[] expressions)
+    public VerifySettings IgnoreMembers<T>(params Expression<Func<T, object?>>[] expressions)
         where T : notnull
     {
         CloneSettings();
         serialization.IgnoreMembers(expressions);
+        return this;
     }
 
-    public void ScrubMembers<T>(params Expression<Func<T, object?>>[] expressions)
+    public VerifySettings ScrubMembers<T>(params Expression<Func<T, object?>>[] expressions)
         where T : notnull
     {
         CloneSettings();
         serialization.ScrubMembers(expressions);
+        return this;
     }
 
-    public void IgnoreMember<T>(Expression<Func<T, object?>> expression)
+    public VerifySettings IgnoreMember<T>(Expression<Func<T, object?>> expression)
         where T : notnull
     {
         CloneSettings();
         serialization.IgnoreMembers(expression);
+        return this;
     }
 
-    public void ScrubMember<T>(Expression<Func<T, object?>> expression)
+    public VerifySettings ScrubMember<T>(Expression<Func<T, object?>> expression)
         where T : notnull
     {
         CloneSettings();
         serialization.ScrubMembers(expression);
+        return this;
     }
 
-    public void IgnoreMembers<T>(params string[] names)
+    public VerifySettings IgnoreMembers<T>(params string[] names)
         where T : notnull
     {
         CloneSettings();
         serialization.IgnoreMembers<T>(names);
+        return this;
     }
 
-    public void ScrubMembers<T>(params string[] names)
+    public VerifySettings ScrubMembers<T>(params string[] names)
         where T : notnull
     {
         CloneSettings();
         serialization.ScrubMembers<T>(names);
+        return this;
     }
 
-    public void IgnoreMember<T>(string name)
+    public VerifySettings IgnoreMember<T>(string name)
         where T : notnull
     {
         CloneSettings();
         serialization.IgnoreMember<T>(name);
+        return this;
     }
 
-    public void ScrubMember<T>(string name)
+    public VerifySettings ScrubMember<T>(string name)
         where T : notnull
     {
         CloneSettings();
         serialization.ScrubMember<T>(name);
+        return this;
     }
 
-    public void IgnoreMembers(Type declaringType, params string[] names)
+    public VerifySettings IgnoreMembers(Type declaringType, params string[] names)
     {
         CloneSettings();
         serialization.IgnoreMembers(declaringType, names);
+        return this;
     }
 
-    public void ScrubMembers(Type declaringType, params string[] names)
+    public VerifySettings ScrubMembers(Type declaringType, params string[] names)
     {
         CloneSettings();
         serialization.ScrubMembers(declaringType, names);
+        return this;
     }
 
-    public void IgnoreMember(Type declaringType, string name)
+    public VerifySettings IgnoreMember(Type declaringType, string name)
     {
         CloneSettings();
         serialization.IgnoreMember(declaringType, name);
+        return this;
     }
 
-    public void ScrubMember(Type declaringType, string name)
+    public VerifySettings ScrubMember(Type declaringType, string name)
     {
         CloneSettings();
         serialization.ScrubMember(declaringType, name);
+        return this;
     }
 
-    public void IgnoreMember(string name)
+    public VerifySettings IgnoreMember(string name)
     {
         CloneSettings();
         serialization.IgnoreMember(name);
+        return this;
     }
 
-    public void ScrubMember(string name)
+    public VerifySettings ScrubMember(string name)
     {
         CloneSettings();
         serialization.ScrubMember(name);
+        return this;
     }
 
-    public void IgnoreMembers(params string[] names)
+    public VerifySettings IgnoreMembers(params string[] names)
     {
         CloneSettings();
         serialization.IgnoreMembers(names);
+        return this;
     }
 
-    public void ScrubMembers(params string[] names)
+    public VerifySettings ScrubMembers(params string[] names)
     {
         CloneSettings();
         serialization.ScrubMembers(names);
+        return this;
     }
 
-    public void IgnoreInstance<T>(Func<T, bool> shouldIgnore)
+    public VerifySettings IgnoreInstance<T>(Func<T, bool> shouldIgnore)
         where T : notnull
     {
         CloneSettings();
         serialization.IgnoreInstance(shouldIgnore);
+        return this;
     }
 
-    public void ScrubInstance<T>(Func<T, bool> shouldScrub)
+    public VerifySettings ScrubInstance<T>(Func<T, bool> shouldScrub)
         where T : notnull
     {
         CloneSettings();
         serialization.ScrubInstance(shouldScrub);
+        return this;
     }
 
-    public void OrderEnumerableBy<T>(Func<T, object?> keySelector)
+    public VerifySettings OrderEnumerableBy<T>(Func<T, object?> keySelector)
     {
         CloneSettings();
         serialization.OrderEnumerableBy(keySelector);
+        return this;
     }
 
-    public void OrderEnumerableByDescending<T>(Func<T, object?> keySelector)
+    public VerifySettings OrderEnumerableByDescending<T>(Func<T, object?> keySelector)
     {
         CloneSettings();
         serialization.OrderEnumerableByDescending(keySelector);
+        return this;
     }
 
-    public void IgnoreInstance(Type type, ShouldIgnore shouldIgnore)
+    public VerifySettings IgnoreInstance(Type type, ShouldIgnore shouldIgnore)
     {
         CloneSettings();
         serialization.IgnoreInstance(type, shouldIgnore);
+        return this;
     }
 
-    public void ScrubInstance(Type type, ShouldScrub shouldScrub)
+    public VerifySettings ScrubInstance(Type type, ShouldScrub shouldScrub)
     {
         CloneSettings();
         serialization.ScrubInstance(type, shouldScrub);
+        return this;
     }
 
-    public void IgnoreMembersWithType<T>()
+    public VerifySettings IgnoreMembersWithType<T>()
         where T : notnull
     {
         CloneSettings();
         serialization.IgnoreMembersWithType<T>();
+        return this;
     }
 
-    public void ScrubMembersWithType<T>()
+    public VerifySettings ScrubMembersWithType<T>()
         where T : notnull
     {
         CloneSettings();
         serialization.ScrubMembersWithType<T>();
+        return this;
     }
 
-    public void AlwaysIncludeMembersWithType<T>()
+    public VerifySettings AlwaysIncludeMembersWithType<T>()
         where T : notnull
     {
         CloneSettings();
         serialization.AlwaysIncludeMembersWithType<T>();
+        return this;
     }
 
-    public void IgnoreMembersWithType(Type type)
+    public VerifySettings IgnoreMembersWithType(Type type)
     {
         CloneSettings();
         serialization.IgnoreMembersWithType(type);
+        return this;
     }
 
-    public void ScrubMembersWithType(Type type)
+    public VerifySettings ScrubMembersWithType(Type type)
     {
         CloneSettings();
         serialization.ScrubMembersWithType(type);
+        return this;
     }
 
-    public void AlwaysIncludeMembersWithType(Type type)
+    public VerifySettings AlwaysIncludeMembersWithType(Type type)
     {
         CloneSettings();
         serialization.AlwaysIncludeMembersWithType(type);
+        return this;
     }
 
-    public void IgnoreMembersThatThrow<T>()
+    public VerifySettings IgnoreMembersThatThrow<T>()
         where T : Exception
     {
         CloneSettings();
         serialization.IgnoreMembersThatThrow<T>();
+        return this;
     }
 
-    public void IgnoreMembersThatThrow(Func<Exception, bool> item)
+    public VerifySettings IgnoreMembersThatThrow(Func<Exception, bool> item)
     {
         CloneSettings();
         serialization.IgnoreMembersThatThrow(item);
+        return this;
     }
 
-    public void IgnoreMembersThatThrow<T>(Func<T, bool> item)
+    public VerifySettings IgnoreMembersThatThrow<T>(Func<T, bool> item)
         where T : Exception
     {
         CloneSettings();
         serialization.IgnoreMembersThatThrow(item);
+        return this;
     }
 }

--- a/src/Verify/Splitters/Settings_FileAppender.cs
+++ b/src/Verify/Splitters/Settings_FileAppender.cs
@@ -32,13 +32,19 @@ public partial class VerifySettings
 {
     internal List<Target> appendedFiles = [];
 
-    public void AppendContentAsFile(string content, string extension = "txt", string? name = null) =>
+    public VerifySettings AppendContentAsFile(string content, string extension = "txt", string? name = null)
+    {
         appendedFiles.Add(new(extension, content, name));
+        return this;
+    }
 
-    public void AppendContentAsFile(StringBuilder content, string extension = "txt", string? name = null) =>
+    public VerifySettings AppendContentAsFile(StringBuilder content, string extension = "txt", string? name = null)
+    {
         appendedFiles.Add(new(extension, content, name));
+        return this;
+    }
 
-    public void AppendContentAsFile(byte[] content, string extension = "txt", string? name = null)
+    public VerifySettings AppendContentAsFile(byte[] content, string extension = "txt", string? name = null)
     {
         if (FileExtensions.IsTextExtension(extension))
         {
@@ -48,18 +54,29 @@ public partial class VerifySettings
         {
             appendedFiles.Add(new(extension, new MemoryStream(content), name));
         }
+
+        return this;
     }
 
-    public void AppendFile(string file, string? name = null) =>
+    public VerifySettings AppendFile(string file, string? name = null)
+    {
         AppendFile(IoHelpers.OpenRead(file), name);
+        return this;
+    }
 
-    public void AppendFile(FileInfo file, string? name = null) =>
+    public VerifySettings AppendFile(FileInfo file, string? name = null)
+    {
         AppendFile(file.FullName, name);
+        return this;
+    }
 
-    public void AppendFile(FileStream stream, string? name = null) =>
+    public VerifySettings AppendFile(FileStream stream, string? name = null)
+    {
         AppendFile(stream, stream.Extension(), name ?? Path.GetFileNameWithoutExtension(stream.Name));
+        return this;
+    }
 
-    public void AppendFile(Stream stream, string extension = "txt", string? name = null)
+    public VerifySettings AppendFile(Stream stream, string extension = "txt", string? name = null)
     {
         stream.MoveToStart();
         if (FileExtensions.IsTextExtension(extension))
@@ -71,6 +88,8 @@ public partial class VerifySettings
         {
             appendedFiles.Add(new(extension, stream, name));
         }
+
+        return this;
     }
 }
 

--- a/src/Verify/VerifySettings.cs
+++ b/src/Verify/VerifySettings.cs
@@ -93,7 +93,7 @@ public partial class VerifySettings
     /// Not compatible with <see cref="UseParameters" />.
     /// Where the file format is `{CurrentDirectory}/{TestClassName}.{TestMethodName}_{Parameters}_{UniqueFor1}_{UniqueFor2}_{UniqueForX}.verified.{extension}`.
     /// </summary>
-    public void UseTextForParameters(string parametersText)
+    public VerifySettings UseTextForParameters(string parametersText)
     {
         Guards.AgainstBadExtension(parametersText);
 
@@ -103,6 +103,8 @@ public partial class VerifySettings
         }
 
         this.parametersText = parametersText;
+
+        return this;
     }
 
     internal AutoVerify? autoVerify;
@@ -110,13 +112,13 @@ public partial class VerifySettings
     /// <summary>
     /// Automatically accept the results of the current test.
     /// </summary>
-    public void AutoVerify(bool includeBuildServer = true) =>
+    public VerifySettings AutoVerify(bool includeBuildServer = true) =>
         AutoVerify(_ => true, includeBuildServer);
 
     /// <summary>
     /// Automatically accept the results of the current test.
     /// </summary>
-    public void AutoVerify(AutoVerify autoVerify, bool includeBuildServer = true)
+    public VerifySettings AutoVerify(AutoVerify autoVerify, bool includeBuildServer = true)
     {
         if (includeBuildServer)
         {
@@ -129,5 +131,7 @@ public partial class VerifySettings
                 this.autoVerify = autoVerify;
             }
         }
+
+        return this;
     }
 }


### PR DESCRIPTION
Feel free to close if you don't want this change.

If you have various options you want to set, it can feel verbose to have to declare a variable and then repetitively having to access it and call various methods on it.

This change would introduce the builder pattern to `VerifySettings` so that methods that amend its configuration return you back the same object, allowing you to chain settings easily and concisely.

This means you don't necessarily have to declare a variable either, you could just inline the settings object into your `Verify(...)` call.

Take this from your documentation:

```csharp
[Fact]
public Task OnCallbacks()
{
    var settings = new VerifySettings();
    settings.OnVerify(
        before: () => Debug.WriteLine("before"),
        after: () => Debug.WriteLine("after"));
    settings.OnFirstVerify(
        (receivedFile, receivedText, autoVerify) =>
        {
            Debug.WriteLine(receivedFile);
            Debug.WriteLine(receivedText);
            return Task.CompletedTask;
        });
    settings.OnVerifyMismatch(
        (filePair, message, autoVerify) =>
        {
            Debug.WriteLine(filePair.ReceivedPath);
            Debug.WriteLine(filePair.VerifiedPath);
            Debug.WriteLine(message);
            return Task.CompletedTask;
        });

    return Verify("value");
}
```

This could become:

```csharp
[Fact]
public Task OnCallbacks() {
    return Verify("value", new VerifySettings()
        .OnVerify(
            before: () => Debug.WriteLine("before"),
            after: () => Debug.WriteLine("after"))
        .OnFirstVerify(
            (receivedFile, receivedText, autoVerify) => {
                Debug.WriteLine(receivedFile);
                Debug.WriteLine(receivedText);
                return Task.CompletedTask;
            })
        .OnVerifyMismatch(
            (filePair, message, autoVerify) => {
                Debug.WriteLine(filePair.ReceivedPath);
                Debug.WriteLine(filePair.VerifiedPath);
                Debug.WriteLine(message);
                return Task.CompletedTask;
            }));
}
```

This of course doesn't stop you defining it the old way either - So the choice is up to the user and remains backwards compatible.