### PR TITLE
Improve build-server-azuredevops.include.md regarding ubuntu runners

### DIFF
--- a/docs/mdsource/build-server-azuredevops.include.md
+++ b/docs/mdsource/build-server-azuredevops.include.md
@@ -5,7 +5,7 @@ Directly after the test runner step add a build step to set a flag if the testru
   displayName: 'Set flag to publish Verify *.received.* files when test step fails'
   condition: failed()
   inputs:
-    script: 'echo ##vso[task.setvariable variable=publishverify]Yes'
+    script: 'echo "##vso[task.setvariable variable=publishverify]Yes"'
 ```
 
 Since the PublishBuildArtifacts step in DevOps does not allow a wildcard it is necessary to stage the 'received' files before publishing:
@@ -15,8 +15,8 @@ Since the PublishBuildArtifacts step in DevOps does not allow a wildcard it is n
   condition: eq(variables['publishverify'], 'Yes')
   displayName: 'Copy Verify *.received.* files to Artifact Staging'
   inputs:
-    contents: '**\*.received.*' 
-    targetFolder: '$(Build.ArtifactStagingDirectory)\Verify'
+    contents: '**/*.received.*' 
+    targetFolder: '$(Build.ArtifactStagingDirectory)/Verify'
     cleanTargetFolder: true
     overWrite: true
 ```
@@ -29,7 +29,7 @@ Publish the staged files as a build artifact:
   name: 'verifypublish'
   condition: eq(variables['publishverify'], 'Yes')
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\Verify'
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/Verify'
     ArtifactName: 'Verify'
     publishLocation: 'Container'
 ```


### PR DESCRIPTION
Thanks for creating Verify, I think it is a very valuable tool!

I needed to apply these changes to make publishing of `*.received.*` files work on public AzDO ubuntu runners.

Note: My pipeline is linux-only and I didn't test this with a windows pipeline, but I _think_ these changes should be compatible.

For reference, this is the relevant snippet (not 100% == what's in the docs) from my azure-pipelines.yml that actually works in my production pipeline:

```yml
# Publish Verify *.received.* files if test step fails
# https://github.com/VerifyTests/Verify/blob/main/docs/build-server.md#azure-devops-yaml-pipeline
- bash: |
    echo "##vso[task.setvariable variable=publishverify]Yes"
  displayName: '⚙ Publish Verify *.received.* files if test step fails'
  condition: failed()

- task: CopyFiles@2
  condition: eq(variables['publishverify'], 'Yes')
  displayName: 'Copy Verify *.received.* files to Artifact Staging'
  inputs:
    contents: '**/*.received.*'
    targetFolder: '$(Build.ArtifactStagingDirectory)/Verify'
    cleanTargetFolder: true
    overWrite: true

- publish: '$(Build.ArtifactStagingDirectory)/Verify'
  condition: eq(variables['publishverify'], 'Yes')
  displayName: '📢 Publish Verify *.received.* files'
  artifact: 'Verify'
# End of Verify *.received.* files publishing
```

I wasn't sure if I should update <https://github.com/VerifyTests/Verify/edit/main/docs/build-server.md> as part of this PR too, let me know if so.