### PR TITLE
Added a readme file to the NuGet packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,7 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>Json, Testing, Verify, Snapshot, Approvals</PackageTags>
     <Description>Enables verification of complex models and documents.</Description>
+    <PackageReadmeFile>readme.source.md</PackageReadmeFile>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <ResolveAssemblyReferencesSilent>true</ResolveAssemblyReferencesSilent>
     <NuGetAuditMode>all</NuGetAuditMode>
@@ -17,6 +18,12 @@
     <PolyGuard>true</PolyGuard>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(SolutionDir)\..\readme.source.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
   <ItemGroup>
     <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Globalization" />


### PR DESCRIPTION
With the Visual Studio 17.13 update the NuGet package manager/browser [shows a preview of the included readme](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes#net).

Might want to consider embedding a readme with the packages moving forward, otherwise Visual Studio shows the following:

![missing readme preview in visual studio](https://github.com/user-attachments/assets/e5cf4d74-d348-446d-94cb-f0b7f0fc4ba2)

Ideally, each package would have a dedicated readme, but that would probably be too annoying to maintain, so for now I included the same file in every package.

I included the `readme.source.md` file, though if you'd prefer `readme.md` instead, I can change that.