### PR TITLE
docs(readme): add note about binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@ src/Verify/EmptyFiles/* binary
 *.verified.json text eol=lf working-tree-encoding=UTF-8
 *.verified.props text eol=lf working-tree-encoding=UTF-8
 *.verified.nuspec text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 
 src/.editorconfig text eol=lf working-tree-encoding=UTF-8
 *.sln.DotSettings text eol=lf working-tree-encoding=UTF-8

--- a/docs/mdsource/text-file-settings.include.md
+++ b/docs/mdsource/text-file-settings.include.md
@@ -14,12 +14,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_Expecto_AppVeyor.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_Expecto_AzureDevOps.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_Expecto_GitHubActions.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Expecto_None.md
+++ b/docs/wiz/Linux_Other_Cli_Expecto_None.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_Fixie_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_Fixie_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_Fixie_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Fixie_None.md
+++ b/docs/wiz/Linux_Other_Cli_Fixie_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_MSTest_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_MSTest_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_MSTest_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_MSTest_None.md
+++ b/docs/wiz/Linux_Other_Cli_MSTest_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_NUnit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_NUnit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_NUnit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_NUnit_None.md
+++ b/docs/wiz/Linux_Other_Cli_NUnit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_TUnit_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_TUnit_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_TUnit_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_TUnit_None.md
+++ b/docs/wiz/Linux_Other_Cli_TUnit_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_XunitV3_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_XunitV3_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_XunitV3_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_XunitV3_None.md
+++ b/docs/wiz/Linux_Other_Cli_XunitV3_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_Xunit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_Xunit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_Xunit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Cli_Xunit_None.md
+++ b/docs/wiz/Linux_Other_Cli_Xunit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_Expecto_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_Expecto_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_Expecto_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Expecto_None.md
+++ b/docs/wiz/Linux_Other_Gui_Expecto_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_Fixie_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_Fixie_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_Fixie_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Fixie_None.md
+++ b/docs/wiz/Linux_Other_Gui_Fixie_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_AppVeyor.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_AzureDevOps.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_GitHubActions.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_MSTest_None.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_None.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_NUnit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_NUnit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_NUnit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_NUnit_None.md
+++ b/docs/wiz/Linux_Other_Gui_NUnit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_TUnit_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_TUnit_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_TUnit_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_TUnit_None.md
+++ b/docs/wiz/Linux_Other_Gui_TUnit_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_XunitV3_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_XunitV3_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_XunitV3_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_XunitV3_None.md
+++ b/docs/wiz/Linux_Other_Gui_XunitV3_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_Xunit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_Xunit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_Xunit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Other_Gui_Xunit_None.md
+++ b/docs/wiz/Linux_Other_Gui_Xunit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_Expecto_AppVeyor.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_Expecto_AzureDevOps.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_Expecto_GitHubActions.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Expecto_None.md
+++ b/docs/wiz/Linux_Rider_Cli_Expecto_None.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_Fixie_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_Fixie_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_Fixie_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Fixie_None.md
+++ b/docs/wiz/Linux_Rider_Cli_Fixie_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_MSTest_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_MSTest_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_MSTest_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_MSTest_None.md
+++ b/docs/wiz/Linux_Rider_Cli_MSTest_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_NUnit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_NUnit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_NUnit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_NUnit_None.md
+++ b/docs/wiz/Linux_Rider_Cli_NUnit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_TUnit_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_TUnit_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_TUnit_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_TUnit_None.md
+++ b/docs/wiz/Linux_Rider_Cli_TUnit_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_XunitV3_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_XunitV3_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_XunitV3_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_XunitV3_None.md
+++ b/docs/wiz/Linux_Rider_Cli_XunitV3_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_Xunit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_Xunit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_Xunit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Cli_Xunit_None.md
+++ b/docs/wiz/Linux_Rider_Cli_Xunit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_Expecto_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_Expecto_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_Expecto_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Expecto_None.md
+++ b/docs/wiz/Linux_Rider_Gui_Expecto_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_Fixie_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_Fixie_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_Fixie_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Fixie_None.md
+++ b/docs/wiz/Linux_Rider_Gui_Fixie_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_AppVeyor.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_AzureDevOps.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_GitHubActions.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_MSTest_None.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_None.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_NUnit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_NUnit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_NUnit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_NUnit_None.md
+++ b/docs/wiz/Linux_Rider_Gui_NUnit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_TUnit_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_TUnit_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_TUnit_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_TUnit_None.md
+++ b/docs/wiz/Linux_Rider_Gui_TUnit_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_XunitV3_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_XunitV3_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_XunitV3_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_XunitV3_None.md
+++ b/docs/wiz/Linux_Rider_Gui_XunitV3_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_Xunit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_Xunit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_Xunit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Linux_Rider_Gui_Xunit_None.md
+++ b/docs/wiz/Linux_Rider_Gui_Xunit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_Expecto_AppVeyor.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_Expecto_AzureDevOps.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_Expecto_GitHubActions.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Expecto_None.md
+++ b/docs/wiz/MacOS_Other_Cli_Expecto_None.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_Fixie_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_Fixie_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_Fixie_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Fixie_None.md
+++ b/docs/wiz/MacOS_Other_Cli_Fixie_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_MSTest_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_MSTest_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_MSTest_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_MSTest_None.md
+++ b/docs/wiz/MacOS_Other_Cli_MSTest_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_NUnit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_NUnit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_NUnit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_NUnit_None.md
+++ b/docs/wiz/MacOS_Other_Cli_NUnit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_TUnit_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_TUnit_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_TUnit_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_TUnit_None.md
+++ b/docs/wiz/MacOS_Other_Cli_TUnit_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_XunitV3_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_XunitV3_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_XunitV3_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_XunitV3_None.md
+++ b/docs/wiz/MacOS_Other_Cli_XunitV3_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_Xunit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_Xunit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_Xunit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Cli_Xunit_None.md
+++ b/docs/wiz/MacOS_Other_Cli_Xunit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_Expecto_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_Expecto_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_Expecto_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Expecto_None.md
+++ b/docs/wiz/MacOS_Other_Gui_Expecto_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_Fixie_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_Fixie_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_Fixie_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Fixie_None.md
+++ b/docs/wiz/MacOS_Other_Gui_Fixie_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_AppVeyor.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_AzureDevOps.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_GitHubActions.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_MSTest_None.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_None.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_NUnit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_NUnit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_NUnit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_NUnit_None.md
+++ b/docs/wiz/MacOS_Other_Gui_NUnit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_TUnit_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_TUnit_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_TUnit_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_TUnit_None.md
+++ b/docs/wiz/MacOS_Other_Gui_TUnit_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_XunitV3_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_XunitV3_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_XunitV3_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_XunitV3_None.md
+++ b/docs/wiz/MacOS_Other_Gui_XunitV3_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_Xunit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_Xunit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_Xunit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Other_Gui_Xunit_None.md
+++ b/docs/wiz/MacOS_Other_Gui_Xunit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_Expecto_AppVeyor.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_Expecto_AzureDevOps.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_Expecto_GitHubActions.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Expecto_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_Expecto_None.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_Fixie_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_Fixie_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_Fixie_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Fixie_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_Fixie_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_MSTest_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_MSTest_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_MSTest_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_MSTest_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_MSTest_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_NUnit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_NUnit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_NUnit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_NUnit_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_NUnit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_TUnit_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_TUnit_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_TUnit_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_TUnit_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_TUnit_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_XunitV3_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_XunitV3_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_XunitV3_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_XunitV3_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_XunitV3_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_Xunit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_Xunit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_Xunit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Cli_Xunit_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_Xunit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_Expecto_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_Expecto_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_Expecto_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Expecto_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_Expecto_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_Fixie_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_Fixie_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_Fixie_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Fixie_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_Fixie_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_AppVeyor.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_AzureDevOps.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_GitHubActions.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_None.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_NUnit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_NUnit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_NUnit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_NUnit_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_NUnit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_TUnit_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_TUnit_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_TUnit_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_TUnit_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_TUnit_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_XunitV3_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_XunitV3_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_XunitV3_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_XunitV3_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_XunitV3_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_Xunit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_Xunit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_Xunit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/MacOS_Rider_Gui_Xunit_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_Xunit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_Expecto_AppVeyor.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_Expecto_AzureDevOps.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_Expecto_GitHubActions.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Expecto_None.md
+++ b/docs/wiz/Windows_Other_Cli_Expecto_None.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_Fixie_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_Fixie_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_Fixie_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Fixie_None.md
+++ b/docs/wiz/Windows_Other_Cli_Fixie_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_MSTest_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_MSTest_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_MSTest_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_MSTest_None.md
+++ b/docs/wiz/Windows_Other_Cli_MSTest_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_NUnit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_NUnit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_NUnit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_NUnit_None.md
+++ b/docs/wiz/Windows_Other_Cli_NUnit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_TUnit_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_TUnit_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_TUnit_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_TUnit_None.md
+++ b/docs/wiz/Windows_Other_Cli_TUnit_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_XunitV3_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_XunitV3_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_XunitV3_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_XunitV3_None.md
+++ b/docs/wiz/Windows_Other_Cli_XunitV3_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_Xunit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_Xunit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_Xunit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Cli_Xunit_None.md
+++ b/docs/wiz/Windows_Other_Cli_Xunit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_Expecto_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_Expecto_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_Expecto_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Expecto_None.md
+++ b/docs/wiz/Windows_Other_Gui_Expecto_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_Fixie_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_Fixie_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_Fixie_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Fixie_None.md
+++ b/docs/wiz/Windows_Other_Gui_Fixie_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_AppVeyor.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_AzureDevOps.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_GitHubActions.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_None.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_NUnit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_NUnit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_NUnit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_NUnit_None.md
+++ b/docs/wiz/Windows_Other_Gui_NUnit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_TUnit_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_TUnit_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_TUnit_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_TUnit_None.md
+++ b/docs/wiz/Windows_Other_Gui_TUnit_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_XunitV3_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_XunitV3_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_XunitV3_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_XunitV3_None.md
+++ b/docs/wiz/Windows_Other_Gui_XunitV3_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_Xunit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_Xunit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_Xunit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Other_Gui_Xunit_None.md
+++ b/docs/wiz/Windows_Other_Gui_Xunit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_Expecto_AppVeyor.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_Expecto_AzureDevOps.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_Expecto_GitHubActions.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Expecto_None.md
+++ b/docs/wiz/Windows_Rider_Cli_Expecto_None.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_Fixie_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_Fixie_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_Fixie_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Fixie_None.md
+++ b/docs/wiz/Windows_Rider_Cli_Fixie_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_MSTest_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_MSTest_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_MSTest_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_MSTest_None.md
+++ b/docs/wiz/Windows_Rider_Cli_MSTest_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_NUnit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_NUnit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_NUnit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_NUnit_None.md
+++ b/docs/wiz/Windows_Rider_Cli_NUnit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_TUnit_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_TUnit_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_TUnit_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_TUnit_None.md
+++ b/docs/wiz/Windows_Rider_Cli_TUnit_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_XunitV3_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_XunitV3_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_XunitV3_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_XunitV3_None.md
+++ b/docs/wiz/Windows_Rider_Cli_XunitV3_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_Xunit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_Xunit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_Xunit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Cli_Xunit_None.md
+++ b/docs/wiz/Windows_Rider_Cli_Xunit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_Expecto_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_Expecto_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_Expecto_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Expecto_None.md
+++ b/docs/wiz/Windows_Rider_Gui_Expecto_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_Fixie_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_Fixie_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_Fixie_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Fixie_None.md
+++ b/docs/wiz/Windows_Rider_Gui_Fixie_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_AppVeyor.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_AzureDevOps.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_GitHubActions.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_None.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_NUnit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_NUnit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_NUnit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_NUnit_None.md
+++ b/docs/wiz/Windows_Rider_Gui_NUnit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_TUnit_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_TUnit_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_TUnit_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_TUnit_None.md
+++ b/docs/wiz/Windows_Rider_Gui_TUnit_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_XunitV3_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_XunitV3_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_XunitV3_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_XunitV3_None.md
+++ b/docs/wiz/Windows_Rider_Gui_XunitV3_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_Xunit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_Xunit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_Xunit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_Rider_Gui_Xunit_None.md
+++ b/docs/wiz/Windows_Rider_Gui_Xunit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_AppVeyor.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_AzureDevOps.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_GitHubActions.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_None.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AppVeyor.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AzureDevOps.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_GitHubActions.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_None.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Expecto_AppVeyor.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Expecto_AzureDevOps.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Expecto_GitHubActions.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Expecto_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Expecto_None.md
@@ -69,12 +69,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Fixie_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Fixie_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Fixie_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Fixie_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Fixie_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_MSTest_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_MSTest_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_MSTest_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_MSTest_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_NUnit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_NUnit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_NUnit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_NUnit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_NUnit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_TUnit_AppVeyor.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_TUnit_AzureDevOps.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_TUnit_GitHubActions.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_TUnit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_TUnit_None.md
@@ -68,12 +68,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_XunitV3_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_XunitV3_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_XunitV3_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_XunitV3_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_XunitV3_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Xunit_AppVeyor.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Xunit_AzureDevOps.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Xunit_GitHubActions.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Cli_Xunit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Xunit_None.md
@@ -70,12 +70,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Expecto_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Expecto_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Expecto_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Expecto_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Expecto_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Fixie_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Fixie_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Fixie_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Fixie_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Fixie_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_AppVeyor.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_AzureDevOps.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_GitHubActions.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_None.md
@@ -75,12 +75,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_NUnit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_NUnit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_NUnit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_NUnit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_NUnit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_TUnit_AppVeyor.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_TUnit_AzureDevOps.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_TUnit_GitHubActions.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_TUnit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_TUnit_None.md
@@ -74,12 +74,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_XunitV3_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_XunitV3_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_XunitV3_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_XunitV3_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_XunitV3_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Xunit_AppVeyor.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Xunit_AzureDevOps.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Xunit_GitHubActions.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/docs/wiz/Windows_VisualStudio_Gui_Xunit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Xunit_None.md
@@ -76,12 +76,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -615,12 +615,15 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
+ All Binary files should also be marked to avoid merging and line ending issues with binary files.
+
 eg add the following to `.gitattributes`
 
 ```
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -615,7 +615,7 @@ All text extensions of `*.verified.*` should have:
  * `eol` set to `lf`
  * `working-tree-encoding` set to `UTF-8`
 
- All Binary files should also be marked to avoid merging and line ending issues with binary files.
+All Binary files should also be marked to avoid merging and line ending issues with binary files.
 
 eg add the following to `.gitattributes`
 

--- a/src/Verify.Tests/InnerVerifyChecksTests/Valid/.gitattributes
+++ b/src/Verify.Tests/InnerVerifyChecksTests/Valid/.gitattributes
@@ -8,4 +8,5 @@
 
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.html text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 

--- a/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.GitAttributes.verified.txt
+++ b/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.GitAttributes.verified.txt
@@ -8,6 +8,7 @@ Recommended settings:
 # Verify
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ,
   StackTrace: 
 }

--- a/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.PartialGitAttributes.verified.txt
+++ b/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.PartialGitAttributes.verified.txt
@@ -8,6 +8,7 @@ Recommended settings:
 # Verify
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.bin binary
 ,
   StackTrace: 
 }

--- a/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.cs
+++ b/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable InnerVerifyChecks
+#pragma warning disable InnerVerifyChecks
 public class VerifyChecksTests
 {
     static readonly string invalidDirectory;
@@ -10,6 +10,8 @@ public class VerifyChecksTests
         "json",
         "bin"
     ];
+
+    static List<string> editorConfigExtensions = extensions.Except("bin").ToList();
 
     static VerifyChecksTests()
     {
@@ -47,11 +49,11 @@ public class VerifyChecksTests
 
     [Fact]
     public Task EditorConfig() => ThrowsTask(() =>
-        InnerVerifyChecks.CheckEditorConfig(invalidDirectory, extensions));
+        InnerVerifyChecks.CheckEditorConfig(invalidDirectory, editorConfigExtensions));
 
     [Fact]
     public Task PartialEditorConfig() =>
-        ThrowsTask(() => InnerVerifyChecks.CheckEditorConfig(partialDirectory, extensions));
+        ThrowsTask(() => InnerVerifyChecks.CheckEditorConfig(partialDirectory, editorConfigExtensions));
 
     [Fact]
     public Task PartialGitAttributes() =>

--- a/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.cs
+++ b/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.cs
@@ -7,7 +7,8 @@ public class VerifyChecksTests
     static List<string> extensions =
     [
         "txt",
-        "json"
+        "json",
+        "bin"
     ];
 
     static VerifyChecksTests()

--- a/src/Verify/ConventionCheck/InnerVerifyChecks.cs
+++ b/src/Verify/ConventionCheck/InnerVerifyChecks.cs
@@ -151,7 +151,12 @@ public static class InnerVerifyChecks
         List<string> expected = [];
         foreach (var extension in extensions)
         {
-            var line = $"*.verified.{extension} text eol=lf working-tree-encoding=UTF-8";
+            string line;
+            if (extension == "bin")
+                line ="*.verified.bin binary";
+            else
+                line = $"*.verified.{extension} text eol=lf working-tree-encoding=UTF-8";
+
             expected.Add(line);
             if (text.Contains(line))
             {


### PR DESCRIPTION
Im using Verify to verify some binary files/streams and experience a lot of issues for a few days until I found out that git was treating them like text and auto-merging them etc.

This little bit of documentation should help fix that for others.