### PR TITLE
Add support for MSTest v4

### DIFF
--- a/docs/parameterised-mstest.md
+++ b/docs/parameterised-mstest.md
@@ -19,7 +19,7 @@ If not all parameters are required, a subset can be passed in. In this scenario,
 <!-- snippet: UseParametersSubSetMSTest -->
 <a id='snippet-UseParametersSubSetMSTest'></a>
 ```cs
-[DataTestMethod]
+[TestMethod]
 [DataRow("Value1", "Value2", "Value3")]
 public Task UseParametersSubSet(string arg1, string arg2, string arg3)
 {
@@ -39,7 +39,7 @@ If the number of parameters passed to `UseParameters()` is greater than the numb
 <!-- snippet: DataRowInstanceMSTest -->
 <a id='snippet-DataRowInstanceMSTest'></a>
 ```cs
-[DataTestMethod]
+[TestMethod]
 [DataRow("Value1")]
 [DataRow("Value2")]
 public Task DataRowUsage(string arg) =>
@@ -72,7 +72,7 @@ For the fluent case:
 <!-- snippet: UseTextForParametersMSTest -->
 <a id='snippet-UseTextForParametersMSTest'></a>
 ```cs
-[DataTestMethod]
+[TestMethod]
 [DataRow("Value1")]
 public Task UseTextForParameters(string arg) =>
     Verify(arg)
@@ -108,7 +108,7 @@ For the fluent case:
 <!-- snippet: IgnoreParametersForVerifiedMSTest -->
 <a id='snippet-IgnoreParametersForVerifiedMSTest'></a>
 ```cs
-[DataTestMethod]
+[TestMethod]
 [DataRow("One")]
 [DataRow("Two")]
 public Task IgnoreParametersForVerified(string arg)
@@ -127,7 +127,7 @@ public Task IgnoreParametersForVerified(string arg)
 <!-- snippet: IgnoreParametersForVerifiedFluentMSTest -->
 <a id='snippet-IgnoreParametersForVerifiedFluentMSTest'></a>
 ```cs
-[DataTestMethod]
+[TestMethod]
 [DataRow("One")]
 [DataRow("Two")]
 public Task IgnoreParametersForVerifiedFluent(string arg) =>
@@ -148,7 +148,7 @@ The parameters passed to IgnoreParametersForVerified can be used pass custom par
 <!-- snippet: IgnoreParametersForVerifiedCustomParamsMSTest -->
 <a id='snippet-IgnoreParametersForVerifiedCustomParamsMSTest'></a>
 ```cs
-[DataTestMethod]
+[TestMethod]
 [DataRow("One")]
 [DataRow("Two")]
 public Task IgnoreParametersForVerifiedCustomParams(string arg)
@@ -167,7 +167,7 @@ public Task IgnoreParametersForVerifiedCustomParams(string arg)
 <!-- snippet: IgnoreParametersForVerifiedCustomParamsFluentMSTest -->
 <a id='snippet-IgnoreParametersForVerifiedCustomParamsFluentMSTest'></a>
 ```cs
-[DataTestMethod]
+[TestMethod]
 [DataRow("One")]
 [DataRow("Two")]
 public Task IgnoreParametersForVerifiedFluentCustomParams(string arg) =>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="MSTest" Version="3.9.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageVersion Include="MSTest" Version="4.0.0-preview.25358.7" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.0.0-preview.25358.7" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="Polyfill" Version="9.0.0-beta.9" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.156" />

--- a/src/Verify.MSTest.DerivePaths.Tests/Tests.cs
+++ b/src/Verify.MSTest.DerivePaths.Tests/Tests.cs
@@ -56,7 +56,7 @@ public partial class Tests
             .GetInvalidFileNameChars()
             .First()
             .ToString()));
-        return Assert.ThrowsExceptionAsync<ArgumentException>(() => Verify("Value"));
+        return Assert.ThrowsExactlyAsync<ArgumentException>(() => Verify("Value"));
     }
 
     [TestMethod]
@@ -67,7 +67,7 @@ public partial class Tests
             .GetInvalidFileNameChars()
             .First()
             .ToString()));
-        return Assert.ThrowsExceptionAsync<ArgumentException>(() => Verify("Value"));
+        return Assert.ThrowsExactlyAsync<ArgumentException>(() => Verify("Value"));
     }
 
     [TestMethod]
@@ -78,6 +78,6 @@ public partial class Tests
             .GetInvalidPathChars()
             .First()
             .ToString()));
-        return Assert.ThrowsExceptionAsync<ArgumentException>(() => Verify("Value"));
+        return Assert.ThrowsExactlyAsync<ArgumentException>(() => Verify("Value"));
     }
 }

--- a/src/Verify.MSTest.DisableAttachments.Tests/DisableAttachmentsTests.cs
+++ b/src/Verify.MSTest.DisableAttachments.Tests/DisableAttachmentsTests.cs
@@ -9,7 +9,7 @@ public class DisableAttachmentsTests : VerifyBase
         VerifierSettings.DisableAttachments();
         var settings = new VerifySettings();
         settings.DisableDiff();
-        return Assert.ThrowsExceptionAsync<VerifyException>(
+        return Assert.ThrowsExactlyAsync<VerifyException>(
             () => Verify("Bar", settings));
     }
 }

--- a/src/Verify.MSTest.DisableAttachments.Tests/ResultFilesCallback.cs
+++ b/src/Verify.MSTest.DisableAttachments.Tests/ResultFilesCallback.cs
@@ -3,11 +3,11 @@
 {
     public static Action<List<string>>? Callback;
 
-    public override TestResult[] Execute(ITestMethod testMethod)
+    public override async Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
     {
         try
         {
-            var results = base.Execute(testMethod);
+            var results = await base.ExecuteAsync(testMethod);
 
             if (Callback == null)
             {

--- a/src/Verify.MSTest.SourceGenerator.Tests/CodeAnalysisVersionTests.cs
+++ b/src/Verify.MSTest.SourceGenerator.Tests/CodeAnalysisVersionTests.cs
@@ -1,3 +1,4 @@
+using Assert = Xunit.Assert;
 using CSharpExtensions = Microsoft.CodeAnalysis.CSharp.CSharpExtensions;
 
 public class CodeAnalysisVersionTests(ITestOutputHelper output) : TestBase(output)

--- a/src/Verify.MSTest.SourceGenerator.Tests/TestBase.cs
+++ b/src/Verify.MSTest.SourceGenerator.Tests/TestBase.cs
@@ -1,5 +1,7 @@
 // These tests don't use Verify.SourceGenerator to avoid creating a circular dependency between the repos.
 
+using Assert = Xunit.Assert;
+
 public abstract class TestBase(ITestOutputHelper output)
 {
     private protected TestDriver TestDriver { get; } = new([new UsesVerifyGenerator().AsSourceGenerator()]);

--- a/src/Verify.MSTest.Tests/ResultFilesCallback.cs
+++ b/src/Verify.MSTest.Tests/ResultFilesCallback.cs
@@ -1,13 +1,13 @@
-﻿sealed class ResultFilesCallback :
+sealed class ResultFilesCallback :
     TestMethodAttribute
 {
     public static Action<List<string>>? Callback;
 
-    public override TestResult[] Execute(ITestMethod testMethod)
+    public override async Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
     {
         try
         {
-            var results = base.Execute(testMethod);
+            var results = await base.ExecuteAsync(testMethod);
 
             if (Callback == null)
             {
@@ -15,10 +15,9 @@
             }
 
             Callback(
-                results
+                [.. results
                     .Where(_ => _.ResultFiles != null)
-                    .SelectMany(_ => _.ResultFiles!)
-                    .ToList());
+                    .SelectMany(_ => _.ResultFiles!)]);
 
             return results;
         }

--- a/src/Verify.MSTest.Tests/Snippets/ParametersSample.cs
+++ b/src/Verify.MSTest.Tests/Snippets/ParametersSample.cs
@@ -3,7 +3,7 @@ public partial class ParametersSample
 {
     #region UseTextForParametersMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("Value1")]
     public Task UseTextForParameters(string arg) =>
         Verify(arg)
@@ -13,7 +13,7 @@ public partial class ParametersSample
 
     #region DataRowInstanceMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("Value1")]
     [DataRow("Value2")]
     public Task DataRowUsage(string arg) =>
@@ -23,7 +23,7 @@ public partial class ParametersSample
 
     #region IgnoreParametersForVerifiedMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("One")]
     [DataRow("Two")]
     public Task IgnoreParametersForVerified(string arg)
@@ -37,7 +37,7 @@ public partial class ParametersSample
 
     #region IgnoreParametersForVerifiedFluentMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("One")]
     [DataRow("Two")]
     public Task IgnoreParametersForVerifiedFluent(string arg) =>
@@ -48,7 +48,7 @@ public partial class ParametersSample
 
     #region IgnoreParametersForVerifiedCustomParamsMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("One")]
     [DataRow("Two")]
     public Task IgnoreParametersForVerifiedCustomParams(string arg)
@@ -62,7 +62,7 @@ public partial class ParametersSample
 
     #region IgnoreParametersForVerifiedCustomParamsFluentMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("One")]
     [DataRow("Two")]
     public Task IgnoreParametersForVerifiedFluentCustomParams(string arg) =>
@@ -73,7 +73,7 @@ public partial class ParametersSample
 
     #region IgnoreParametersMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("One")]
     [DataRow("Two")]
     public Task IgnoreParameters(string arg)
@@ -87,7 +87,7 @@ public partial class ParametersSample
 
     #region IgnoreParametersFluentMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("One")]
     [DataRow("Two")]
     public Task IgnoreParametersFluent(string arg) =>
@@ -98,7 +98,7 @@ public partial class ParametersSample
 
     #region IgnoreParametersCustomParamsMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("One")]
     [DataRow("Two")]
     public Task IgnoreParametersCustomParams(string arg)
@@ -113,7 +113,7 @@ public partial class ParametersSample
 
     #region UseParametersSubSetMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("Value1", "Value2", "Value3")]
     public Task UseParametersSubSet(string arg1, string arg2, string arg3)
     {
@@ -126,7 +126,7 @@ public partial class ParametersSample
 
     #region IgnoreParametersCustomParamsFluentMSTest
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("One")]
     [DataRow("Two")]
     public Task IgnoreParametersFluentCustomParams(string arg) =>

--- a/src/Verify.MSTest.Tests/Snippets/ParametersTests.cs
+++ b/src/Verify.MSTest.Tests/Snippets/ParametersTests.cs
@@ -1,19 +1,19 @@
 [TestClass]
 public partial class ParametersTests
 {
-    //[DataTestMethod]
+    //[TestMethod]
     //[DataRow("1.1")]
     //public async Task Decimal(decimal arg)
     //{
     //    await Verify(arg);
     //}
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow((float) 1.1)]
     public Task Float(float arg) =>
         Verify(arg);
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(1.1d)]
     public Task Double(double arg) =>
         Verify(arg);

--- a/src/Verify.MSTest.Tests/Tests.cs
+++ b/src/Verify.MSTest.Tests/Tests.cs
@@ -20,7 +20,7 @@ public partial class Tests
         #endregion
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("Value1")]
     public Task UseFileNameWithParam(string arg) =>
         Verify(arg)
@@ -42,7 +42,7 @@ public partial class Tests
         };
         var settings = new VerifySettings();
         settings.DisableDiff();
-        await Assert.ThrowsExceptionAsync<VerifyException>(
+        await Assert.ThrowsExactlyAsync<VerifyException>(
             () => Verify("Bar", settings));
     }
 
@@ -82,7 +82,7 @@ public partial class Tests
         };
         var settings = new VerifySettings();
         settings.DisableDiff();
-        await Assert.ThrowsExceptionAsync<VerifyException>(
+        await Assert.ThrowsExactlyAsync<VerifyException>(
             () => Verify("Bar", settings));
     }
 
@@ -100,7 +100,7 @@ public partial class Tests
         };
         var settings = new VerifySettings();
         settings.DisableDiff();
-        await Assert.ThrowsExceptionAsync<VerifyException>(
+        await Assert.ThrowsExactlyAsync<VerifyException>(
             () => Verify("Bar", [new("txt", "Value")], settings));
     }
 
@@ -118,7 +118,7 @@ public partial class Tests
         };
         var settings = new VerifySettings();
         settings.DisableDiff();
-        await Assert.ThrowsExceptionAsync<VerifyException>(
+        await Assert.ThrowsExactlyAsync<VerifyException>(
             () => Verify("Bar", [new("txt", "Value")], settings));
     }
 


### PR DESCRIPTION
Hey @SimonCropp,

As you may have noticed, we have just released preview of MSTest v4. Some internal repos where we want to dogfood MSTest v4 depends on Verify.MSTest so we would appreciate if you would be fine with releasing a alpha/beta/preview of Verify.MSTest for v4.

There are some breaking changes that cause the current version not to be compatible.

I don't know how you would like to handle this so feel free to just steal the code or close if that's too early (and too much work) for now.