### PR TITLE
Test Projects: Include Verify.props and Verify.targets in sequence similar to nuget import sequence

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,6 +17,7 @@
     <PolyGuard>true</PolyGuard>
     <PolyStringInterpolation>true</PolyStringInterpolation>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+	<ImportVerifyMsbuildFiles Condition="'$(MSBuildProjectName)' != '' And $(MSBuildProjectName.EndsWith('Tests'))">true</ImportVerifyMsbuildFiles>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="System.Diagnostics.CodeAnalysis" />
@@ -24,4 +25,6 @@
     <Using Include="System.Linq.Expressions" />
     <Using Include="System.Collections.Specialized" />
   </ItemGroup>
+  <Import Condition="'$(ImportVerifyMsbuildFiles)' == 'true'"
+          Project="$(MSBuildThisFileDirectory)Verify\buildTransitive\Verify.props" />
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Condition="'$(ImportVerifyMsbuildFiles)' == 'true'"
+          Project="$(MSBuildThisFileDirectory)Verify\buildTransitive\Verify.targets" />
+</Project>

--- a/src/FSharpTests/FSharpTests.fsproj
+++ b/src/FSharpTests/FSharpTests.fsproj
@@ -14,7 +14,5 @@
     <ProjectReference Include="..\Verify.Xunit\Verify.Xunit.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
 </Project>

--- a/src/StaticSettingsTests/StaticSettingsTests.csproj
+++ b/src/StaticSettingsTests/StaticSettingsTests.csproj
@@ -11,7 +11,5 @@
     <ProjectReference Include="..\Verify.Xunit\Verify.Xunit.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
 </Project>

--- a/src/StrictJsonTests/StrictJsonTests.csproj
+++ b/src/StrictJsonTests/StrictJsonTests.csproj
@@ -17,7 +17,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
 </Project>

--- a/src/Verify.ClipboardAccept.Tests/Verify.ClipboardAccept.Tests.csproj
+++ b/src/Verify.ClipboardAccept.Tests/Verify.ClipboardAccept.Tests.csproj
@@ -12,7 +12,5 @@
     <ProjectReference Include="..\Verify.Xunit\Verify.Xunit.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
 </Project>

--- a/src/Verify.ExceptionParsing.Tests/Verify.ExceptionParsing.Tests.csproj
+++ b/src/Verify.ExceptionParsing.Tests/Verify.ExceptionParsing.Tests.csproj
@@ -20,8 +20,6 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
 
 </Project>

--- a/src/Verify.Expecto.DerivePaths.Tests/Verify.Expecto.DerivePaths.Tests.csproj
+++ b/src/Verify.Expecto.DerivePaths.Tests/Verify.Expecto.DerivePaths.Tests.csproj
@@ -12,7 +12,5 @@
     <ProjectReference Include="..\Verify.Expecto\Verify.Expecto.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Expecto\buildTransitive\Verify.Expecto.props" />
 </Project>

--- a/src/Verify.Expecto.FSharpTests/Verify.Expecto.FSharpTests.fsproj
+++ b/src/Verify.Expecto.FSharpTests/Verify.Expecto.FSharpTests.fsproj
@@ -16,7 +16,5 @@
     <ProjectReference Include="..\Verify\Verify.csproj" />
     <ProjectReference Include="..\TargetLibrary\TargetLibrary.csproj" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Expecto\buildTransitive\Verify.Expecto.props" />
 </Project>

--- a/src/Verify.Expecto.Tests/Verify.Expecto.Tests.csproj
+++ b/src/Verify.Expecto.Tests/Verify.Expecto.Tests.csproj
@@ -19,7 +19,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Expecto\buildTransitive\Verify.Expecto.props" />
 </Project>

--- a/src/Verify.Fixie.Tests/Verify.Fixie.Tests.csproj
+++ b/src/Verify.Fixie.Tests/Verify.Fixie.Tests.csproj
@@ -21,7 +21,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Fixie\buildTransitive\Verify.Fixie.props" />
 </Project>

--- a/src/Verify.MSTest.DerivePaths.Tests/Verify.MSTest.DerivePaths.Tests.csproj
+++ b/src/Verify.MSTest.DerivePaths.Tests/Verify.MSTest.DerivePaths.Tests.csproj
@@ -10,7 +10,5 @@
     <ProjectReference Include="..\Verify.MSTest.SourceGenerator\Verify.MSTest.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.MSTest\buildTransitive\Verify.MSTest.props" />
 </Project>

--- a/src/Verify.MSTest.DisableAttachments.Tests/Verify.MSTest.DisableAttachments.Tests.csproj
+++ b/src/Verify.MSTest.DisableAttachments.Tests/Verify.MSTest.DisableAttachments.Tests.csproj
@@ -20,8 +20,6 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.MSTest\buildTransitive\Verify.MSTest.props" />
 
 </Project>

--- a/src/Verify.MSTest.SourceGenerator.Tests/Verify.MSTest.SourceGenerator.Tests.csproj
+++ b/src/Verify.MSTest.SourceGenerator.Tests/Verify.MSTest.SourceGenerator.Tests.csproj
@@ -19,8 +19,6 @@
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
 
 </Project>

--- a/src/Verify.MSTest.Tests/Verify.MSTest.Tests.csproj
+++ b/src/Verify.MSTest.Tests/Verify.MSTest.Tests.csproj
@@ -35,8 +35,6 @@
     </None>
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.MSTest\buildTransitive\Verify.MSTest.props" />
 
 </Project>

--- a/src/Verify.NUnit.DerivePaths.Tests/Verify.NUnit.DerivePaths.Tests.csproj
+++ b/src/Verify.NUnit.DerivePaths.Tests/Verify.NUnit.DerivePaths.Tests.csproj
@@ -11,7 +11,5 @@
     <Using Include="NUnit.Framework.Legacy.ClassicAssert" Static="True" />
     <Using Include="NUnit.Framework.Assert" Static="True" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.NUnit\buildTransitive\Verify.NUnit.props" />
 </Project>

--- a/src/Verify.NUnit.DisableAttachments.Tests/Verify.NUnit.DisableAttachments.Tests.csproj
+++ b/src/Verify.NUnit.DisableAttachments.Tests/Verify.NUnit.DisableAttachments.Tests.csproj
@@ -24,8 +24,6 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.NUnit\buildTransitive\Verify.NUnit.props" />
 
 </Project>

--- a/src/Verify.NUnit.Tests/Verify.NUnit.Tests.csproj
+++ b/src/Verify.NUnit.Tests/Verify.NUnit.Tests.csproj
@@ -33,8 +33,6 @@
     </None>
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.NUnit\buildTransitive\Verify.NUnit.props" />
 
 </Project>

--- a/src/Verify.TUnit.DerivePaths.Tests/Verify.TUnit.DerivePaths.Tests.csproj
+++ b/src/Verify.TUnit.DerivePaths.Tests/Verify.TUnit.DerivePaths.Tests.csproj
@@ -10,7 +10,5 @@
     <ProjectReference Include="..\Verify.TUnit\Verify.TUnit.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.TUnit\buildTransitive\Verify.TUnit.props" />
 </Project>

--- a/src/Verify.TUnit.DisableAttachments.Tests/Verify.TUnit.DisableAttachments.Tests.csproj
+++ b/src/Verify.TUnit.DisableAttachments.Tests/Verify.TUnit.DisableAttachments.Tests.csproj
@@ -22,8 +22,6 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.TUnit\buildTransitive\Verify.TUnit.props" />
 
 </Project>

--- a/src/Verify.TUnit.Tests/Verify.TUnit.Tests.csproj
+++ b/src/Verify.TUnit.Tests/Verify.TUnit.Tests.csproj
@@ -31,8 +31,6 @@
     </None>
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.TUnit\buildTransitive\Verify.TUnit.props" />
 
 </Project>

--- a/src/Verify.Tests/Verify.Tests.csproj
+++ b/src/Verify.Tests/Verify.Tests.csproj
@@ -50,8 +50,6 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
 
 </Project>

--- a/src/Verify.Xunit.DerivePaths.Tests/Verify.Xunit.DerivePaths.Tests.csproj
+++ b/src/Verify.Xunit.DerivePaths.Tests/Verify.Xunit.DerivePaths.Tests.csproj
@@ -10,7 +10,5 @@
     <ProjectReference Include="..\Verify.Xunit\Verify.Xunit.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
 </Project>

--- a/src/Verify.Xunit.Tests/Verify.Xunit.Tests.csproj
+++ b/src/Verify.Xunit.Tests/Verify.Xunit.Tests.csproj
@@ -34,8 +34,6 @@
     </None>
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
 
 </Project>

--- a/src/Verify.XunitV3.DerivePaths.Tests/Verify.XunitV3.DerivePaths.Tests.csproj
+++ b/src/Verify.XunitV3.DerivePaths.Tests/Verify.XunitV3.DerivePaths.Tests.csproj
@@ -12,7 +12,5 @@
     <ProjectReference Include="..\Verify.XunitV3\Verify.XunitV3.csproj" />
     <ProjectReference Include="..\Verify\Verify.csproj" />
   </ItemGroup>
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.XunitV3\buildTransitive\Verify.XunitV3.props" />
 </Project>

--- a/src/Verify.XunitV3.Tests/Verify.XunitV3.Tests.csproj
+++ b/src/Verify.XunitV3.Tests/Verify.XunitV3.Tests.csproj
@@ -37,8 +37,6 @@
     </None>
   </ItemGroup>
 
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
-  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
   <Import Project="$(ProjectDir)..\Verify.XunitV3\buildTransitive\Verify.XunitV3.props" />
 
 </Project>

--- a/src/Verify.sln
+++ b/src/Verify.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.gitattributes = ..\.gitattributes
 		appveyor.yml = appveyor.yml
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		mdsnippets.json = mdsnippets.json


### PR DESCRIPTION
By importing them via convention via Directory.Build.props and Directory.Target.props

<img width="1106" height="1214" alt="image" src="https://github.com/user-attachments/assets/e63ac313-53aa-4f38-939a-672ab9019aac" />


> [!Note]
> DeterministicTests.csproj still explicitly imports the files. This is because it defines its own Directory.Build.props, overriding the src directory's Directory.Build.props (not exactly sure if this was intended or not...).
