### PR TITLE
Correctly handle the existence of `TestContext` in base class

### DIFF
--- a/src/Verify.MSTest.SourceGenerator.Tests/InheritanceTests.HasAttributeOnDerivedClassAndPropertyManuallyDefinedInBase.verified.txt
+++ b/src/Verify.MSTest.SourceGenerator.Tests/InheritanceTests.HasAttributeOnDerivedClassAndPropertyManuallyDefinedInBase.verified.txt
@@ -12,7 +12,7 @@
 partial class Derived
 {
   [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Verify.MSTest.SourceGenerator", "1.0.0.0")]
-  public sealed override global::Microsoft.VisualStudio.TestTools.UnitTesting.TestContext TestContext
+  public new global::Microsoft.VisualStudio.TestTools.UnitTesting.TestContext TestContext
   {
     get => base.TestContext;
     set

--- a/src/Verify.MSTest.SourceGenerator.Tests/InheritanceTests.cs
+++ b/src/Verify.MSTest.SourceGenerator.Tests/InheritanceTests.cs
@@ -76,7 +76,7 @@ public class InheritanceTests(ITestOutputHelper output) : TestBase(output)
             }
             """;
 
-        return VerifyGenerator(TestDriver.Run(source), ["CS0506"]);
+        return VerifyGenerator(TestDriver.Run(source));
     }
 
     [Fact]

--- a/src/Verify.MSTest.SourceGenerator/ClassToGenerate.cs
+++ b/src/Verify.MSTest.SourceGenerator/ClassToGenerate.cs
@@ -20,6 +20,7 @@ readonly record struct ClassToGenerate(
         None = 0b00,
         Override = 0b01,
         CallBase = 0b10,
+        New = 0b100,
     }
 
     public string? Namespace { get; } = Namespace;

--- a/src/Verify.MSTest.SourceGenerator/Emitter.cs
+++ b/src/Verify.MSTest.SourceGenerator/Emitter.cs
@@ -131,5 +131,5 @@ class Emitter
     static string GetModifiers(PropertyFlags flags) =>
         flags.HasFlag(PropertyFlags.Override)
             ? "sealed override "
-            : string.Empty;
+            : (flags.HasFlag(PropertyFlags.New) ? "new " : string.Empty);
 }

--- a/src/Verify.MSTest.SourceGenerator/Parser.cs
+++ b/src/Verify.MSTest.SourceGenerator/Parser.cs
@@ -23,9 +23,8 @@ static class Parser
         baseClassProperty?.IsAbstract switch
         {
             true => PropertyFlags.Override,
-            false => PropertyFlags.Override |
-                     PropertyFlags.CallBase,
-            null => PropertyFlags.None
+            false => baseClassProperty.IsVirtual ? PropertyFlags.Override | PropertyFlags.CallBase : PropertyFlags.New | PropertyFlags.CallBase,
+            null => PropertyFlags.None,
         };
 
     static IEnumerable<IPropertySymbol> BaseTestContextProperties(INamedTypeSymbol typeSymbol) =>

--- a/src/Verify.Xunit/Verifier_Object.cs
+++ b/src/Verify.Xunit/Verifier_Object.cs
@@ -1,4 +1,4 @@
-﻿namespace VerifyXunit;
+namespace VerifyXunit;
 
 public static partial class Verifier
 {


### PR DESCRIPTION
Fixes https://github.com/VerifyTests/Verify/issues/1482