### PR TITLE
Avoid unnecessary list instantiation.

### DIFF
--- a/src/Verify/Splitters/Settings_FileAppender.cs
+++ b/src/Verify/Splitters/Settings_FileAppender.cs
@@ -1,4 +1,4 @@
-﻿namespace VerifyTests;
+namespace VerifyTests;
 
 public static partial class VerifierSettings
 {
@@ -37,7 +37,7 @@ public static partial class VerifierSettings
 
 public partial class VerifySettings
 {
-    internal List<Target>? appendedFiles = [];
+    internal List<Target>? appendedFiles;
 
     public void AppendContentAsFile(string content, string extension = "txt", string? name = null)
     {


### PR DESCRIPTION
Minor thing, you forgot to remove the instantiation.

PS. I also use this pattern extensively ([example](https://github.com/fiseni/Pozitron.Extensions.MediatR/blob/main/src/Pozitron.Extensions.MediatR/Publishers/WhenAllPublisher.cs)), and usually I inline it `(appendedFiles ??= []).Add()`.