### PR TITLE
Fix #1574 / F# Solution Explorer Reordering

### DIFF
--- a/src/DeterministicTests/DeterministicTests.csproj
+++ b/src/DeterministicTests/DeterministicTests.csproj
@@ -15,4 +15,5 @@
   </ItemGroup>
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
+  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Condition="'$(ImportVerifyMsbuildFiles)' == 'true'"
+          Project="$(MSBuildThisFileDirectory)Verify\buildTransitive\Verify.targets" />
+</Project>

--- a/src/ModuleInitDocs/ModuleInitDocs.csproj
+++ b/src/ModuleInitDocs/ModuleInitDocs.csproj
@@ -12,4 +12,5 @@
   </ItemGroup>
   <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.props" />
   <Import Project="$(ProjectDir)..\Verify.Xunit\buildTransitive\Verify.Xunit.props" />
+  <Import Project="$(ProjectDir)..\Verify\buildTransitive\Verify.targets" />
 </Project>

--- a/src/Verify.Tests/NugetTests.Run/structure.verified.md
+++ b/src/Verify.Tests/NugetTests.Run/structure.verified.md
@@ -24,9 +24,11 @@
 * buildTransitive
   * Verify.props
   * Verify.AfterMicrosoftNetSdk.props
+  * Verify.targets
 * build
   * Verify.props
   * Verify.AfterMicrosoftNetSdk.props
+  * Verify.targets
 * [Content_Types].xml
 * package
   * services

--- a/src/Verify.slnx
+++ b/src/Verify.slnx
@@ -11,6 +11,7 @@
     <File Path="mdsnippets.json" />
     <File Path="nuget.config" />
     <File Path="testenvironments.json" />
+    <File Path="Directory.Build.targets" />
   </Folder>
   <Project Path="Benchmarks/Benchmarks.csproj" />
   <Project Path="DeterministicTests/DeterministicTests.csproj" />

--- a/src/Verify/Verify.csproj
+++ b/src/Verify/Verify.csproj
@@ -15,6 +15,8 @@
 
     <None Include="buildTransitive\Verify.props" Pack="true" PackagePath="buildTransitive\" />
     <None Include="buildTransitive\Verify.props" Pack="true" PackagePath="build\" />
+    <None Include="buildTransitive\Verify.targets" Pack="true" PackagePath="buildTransitive\" />
+    <None Include="buildTransitive\Verify.targets" Pack="true" PackagePath="build\" />
     <None Include="buildTransitive\Verify.AfterMicrosoftNetSdk.props" Pack="true" PackagePath="buildTransitive\" />
     <None Include="buildTransitive\Verify.AfterMicrosoftNetSdk.props" Pack="true" PackagePath="build\" />
     <!-- Work around https://github.com/dotnet/sdk/issues/51265#issuecomment-3407578810 -->

--- a/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props
+++ b/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props
@@ -9,9 +9,5 @@
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
       <DependentUpon>%(ParentFile).vb</DependentUpon>
     </None>
-    <None Include="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'F#'">
-      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
-      <DependentUpon>%(ParentFile).fs</DependentUpon>
-    </None>
   </ItemGroup>
 </Project>

--- a/src/Verify/buildTransitive/Verify.targets
+++ b/src/Verify/buildTransitive/Verify.targets
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+	<!--
+	for F#, the recieved and verified files are included here to prevent solution item reordering.
+	Also see https://github.com/VerifyTests/Verify/issues/1574
+	-->
+    <None Include="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'F#'">
+      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
+      <DependentUpon>%(ParentFile).fs</DependentUpon>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Description
Addresses items being reordered in Solution Explorer in F# projects as reported in #1574 by moving the `<None Include>` statements for verified/received files to Verify.targets - as was the case pre 30.5 / #1478 - for **F# only**.

## Tests
- Running `FSharpTests` passes
- Rider: In `FSharpTests`, *.verified.* do not show as nested. This is consistent with previous information. Rider shows the item metadata as expected, so.. still don't know why it isn't working correctly. As I've reported before, there seems to be an inconsistency with how Rider evaluates item metadata and the item metadata it shown in the dialog.
<img width="1263" height="717" alt="image" src="https://github.com/user-attachments/assets/6fcb7e1b-8b28-45ed-a334-34e85169fdb1" />

- I can't run tests in Verify.Tests locally:
  > MarkdownSnippets.MsBuild.targets(19,5): Error MSB4018 : The "MarkdownSnippets.DocoTask" task failed unexpectedly.
System.IO.FileNotFoundException: Could not load file or assembly 'System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.
File name: 'System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'