### PR TITLE
Add flag to opt-out of *.received.* and *.verified.* files inclusions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -876,6 +876,14 @@ public static class CurrentFile
 <sup><a href='/src/Verify/CurrentFile.cs#L1-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-CurrentFile.cs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Project inclusion for `*.received.*` and `*.verified.*` files
+Verify comes with default includes for `*.received.*` and `*.verified.*` files as `<None>` elements for C#, VB and F# projects.
+To opt out of this, include the following in your project file:
+```xml
+  <PropertyGroup>
+    <DisableDefaultVerifyNoneItems>true</DisableDefaultVerifyNoneItems>
+  </PropertyGroup>
+```
 
 ## Versioning
 

--- a/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props
+++ b/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
+  <ItemGroup Condition="('$(DisableDefaultVerifyNoneItems)' != 'true')">
     <None Include="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'C#'">
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
       <DependentUpon>%(ParentFile).cs</DependentUpon>

--- a/src/Verify/buildTransitive/Verify.targets
+++ b/src/Verify/buildTransitive/Verify.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
+  <ItemGroup Condition="('$(DisableDefaultVerifyNoneItems)' != 'true')">
 	<!--
 	for F#, the recieved and verified files are included here to prevent solution item reordering.
 	Also see https://github.com/VerifyTests/Verify/issues/1574


### PR DESCRIPTION
@SimonCropp 
I don't know whether you think this important enough to include as it's yet another thing to document and maintain. So feel free to discard this PR.
My thinking here is that it *could* help with support burden - if the inclusion doesn't work like someone wants it to, they can just disable it and implement it themselves, no need for it to be resolved by you.

Anyway thank you very much for all the work you've done for the .net community over all these years! ❤

---

Allows opting out of (nested) inclusion of *.verified.* and *.received.* via:

```xml
﻿<Project>
  <PropertyGroup>
    <DisableDefaultVerifyNoneItems>true</DisableDefaultVerifyNoneItems>
  </PropertyGroup>
</Project>
```

As discussed [here](https://github.com/VerifyTests/Verify/issues/1574#issuecomment-3409420037).

## Why "Disable" instead of "Enable"

in .net you can opt out of the default includes by using
```xml
﻿<Project>
  <PropertyGroup>
    <EnableDefaultItems>false</EnableDefaultItems>
  </PropertyGroup>
</Project>
```

And in [Microsoft.NET.sdk.DefaultItems.prop](https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props)
conditions are specified like:

```xml
<ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
```

However I couldn't find out where `EnableDefaultItems` default value is set to `true` - I think there's some magic going on here.
So it looks to me like this is not applicable for our use case. Instead, in verify the condition looks like:
```xml
 <ItemGroup Condition="('$(DisableDefaultVerifyNoneItems)' != 'true')">
```

So a default value of '' (nothing) leads to the inclusion of the files. Only if you explicitly set the value to `true`, will the files not be included. This leads to the desired opt-out behavior.

## Tests
I have verified with Rider in `Verify.NUnit.Tests` that 
- by default the file inclusions remain
- when setting `<DisableDefaultVerifyNoneItems>true</DisableDefaultVerifyNoneItems>` the `*.verified.*` files don't have a parent anymore (not shown as a child node of a *.cs file in the solution explorer).

However I think it would be best to test this with a pre-release version of the nuget package. AFAIR Inclusion of props/targets just works a bit differently.