### PR TITLE
Update XmlTests.cs

### DIFF
--- a/src/Verify.Tests/XmlTests.cs
+++ b/src/Verify.Tests/XmlTests.cs
@@ -168,7 +168,7 @@ public class XmlTests
     }
 
     [Fact]
-    public Task ScrubAttribute()
+    public Task IgnoreAttribute()
     {
         var document = XDocument.Parse(
             """
@@ -182,7 +182,7 @@ public class XmlTests
     }
 
     [Fact]
-    public Task IgnoreAttribute()
+    public Task ScrubAttribute()
     {
         var document = XDocument.Parse(
             """


### PR DESCRIPTION
A straightforward change: the test name did not match the method called.

`ScrubAttribute()` Test was calling `IgnoreMember`
`IgnoreAttribute()` Test was calling `ScrubMember`

This meant the output file names did not match the behaviour. 