### PR TITLE
Check and document git core.autocrlf setting

### DIFF
--- a/docs/mdsource/text-file-settings.include.md
+++ b/docs/mdsource/text-file-settings.include.md
@@ -26,6 +26,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_Expecto_AppVeyor.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_Expecto_AzureDevOps.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_Expecto_GitHubActions.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Expecto_None.md
+++ b/docs/wiz/Linux_Other_Cli_Expecto_None.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_Fixie_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_Fixie_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_Fixie_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Fixie_None.md
+++ b/docs/wiz/Linux_Other_Cli_Fixie_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_MSTest_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_MSTest_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_MSTest_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_MSTest_None.md
+++ b/docs/wiz/Linux_Other_Cli_MSTest_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_NUnit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_NUnit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_NUnit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_NUnit_None.md
+++ b/docs/wiz/Linux_Other_Cli_NUnit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_TUnit_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_TUnit_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_TUnit_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_TUnit_None.md
+++ b/docs/wiz/Linux_Other_Cli_TUnit_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_XunitV3_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_XunitV3_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_XunitV3_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_XunitV3_None.md
+++ b/docs/wiz/Linux_Other_Cli_XunitV3_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Cli_Xunit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Cli_Xunit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Cli_Xunit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Cli_Xunit_None.md
+++ b/docs/wiz/Linux_Other_Cli_Xunit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_Expecto_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_Expecto_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_Expecto_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Expecto_None.md
+++ b/docs/wiz/Linux_Other_Gui_Expecto_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_Fixie_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_Fixie_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_Fixie_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Fixie_None.md
+++ b/docs/wiz/Linux_Other_Gui_Fixie_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_AppVeyor.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_AzureDevOps.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_GitHubActions.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_MSTest_None.md
+++ b/docs/wiz/Linux_Other_Gui_MSTest_None.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_NUnit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_NUnit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_NUnit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_NUnit_None.md
+++ b/docs/wiz/Linux_Other_Gui_NUnit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_TUnit_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_TUnit_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_TUnit_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_TUnit_None.md
+++ b/docs/wiz/Linux_Other_Gui_TUnit_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_XunitV3_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_XunitV3_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_XunitV3_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_XunitV3_None.md
+++ b/docs/wiz/Linux_Other_Gui_XunitV3_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Linux_Other_Gui_Xunit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Linux_Other_Gui_Xunit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Linux_Other_Gui_Xunit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Other_Gui_Xunit_None.md
+++ b/docs/wiz/Linux_Other_Gui_Xunit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_Expecto_AppVeyor.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_Expecto_AzureDevOps.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_Expecto_GitHubActions.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Expecto_None.md
+++ b/docs/wiz/Linux_Rider_Cli_Expecto_None.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_Fixie_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_Fixie_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_Fixie_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Fixie_None.md
+++ b/docs/wiz/Linux_Rider_Cli_Fixie_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_MSTest_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_MSTest_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_MSTest_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_MSTest_None.md
+++ b/docs/wiz/Linux_Rider_Cli_MSTest_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_NUnit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_NUnit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_NUnit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_NUnit_None.md
+++ b/docs/wiz/Linux_Rider_Cli_NUnit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_TUnit_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_TUnit_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_TUnit_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_TUnit_None.md
+++ b/docs/wiz/Linux_Rider_Cli_TUnit_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_XunitV3_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_XunitV3_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_XunitV3_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_XunitV3_None.md
+++ b/docs/wiz/Linux_Rider_Cli_XunitV3_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Cli_Xunit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Cli_Xunit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Cli_Xunit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Cli_Xunit_None.md
+++ b/docs/wiz/Linux_Rider_Cli_Xunit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_Expecto_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_Expecto_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_Expecto_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Expecto_None.md
+++ b/docs/wiz/Linux_Rider_Gui_Expecto_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_Fixie_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_Fixie_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_Fixie_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Fixie_None.md
+++ b/docs/wiz/Linux_Rider_Gui_Fixie_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_AppVeyor.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_AzureDevOps.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_GitHubActions.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_MSTest_None.md
+++ b/docs/wiz/Linux_Rider_Gui_MSTest_None.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_NUnit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_NUnit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_NUnit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_NUnit_None.md
+++ b/docs/wiz/Linux_Rider_Gui_NUnit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_TUnit_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_TUnit_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_TUnit_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_TUnit_None.md
+++ b/docs/wiz/Linux_Rider_Gui_TUnit_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_XunitV3_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_XunitV3_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_XunitV3_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_XunitV3_None.md
+++ b/docs/wiz/Linux_Rider_Gui_XunitV3_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Linux_Rider_Gui_Xunit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Linux_Rider_Gui_Xunit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Linux_Rider_Gui_Xunit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Linux_Rider_Gui_Xunit_None.md
+++ b/docs/wiz/Linux_Rider_Gui_Xunit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_Expecto_AppVeyor.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_Expecto_AzureDevOps.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_Expecto_GitHubActions.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Expecto_None.md
+++ b/docs/wiz/MacOS_Other_Cli_Expecto_None.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_Fixie_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_Fixie_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_Fixie_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Fixie_None.md
+++ b/docs/wiz/MacOS_Other_Cli_Fixie_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_MSTest_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_MSTest_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_MSTest_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_MSTest_None.md
+++ b/docs/wiz/MacOS_Other_Cli_MSTest_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_NUnit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_NUnit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_NUnit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_NUnit_None.md
+++ b/docs/wiz/MacOS_Other_Cli_NUnit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_TUnit_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_TUnit_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_TUnit_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_TUnit_None.md
+++ b/docs/wiz/MacOS_Other_Cli_TUnit_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_XunitV3_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_XunitV3_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_XunitV3_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_XunitV3_None.md
+++ b/docs/wiz/MacOS_Other_Cli_XunitV3_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Cli_Xunit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Cli_Xunit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Cli_Xunit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Cli_Xunit_None.md
+++ b/docs/wiz/MacOS_Other_Cli_Xunit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_Expecto_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_Expecto_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_Expecto_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Expecto_None.md
+++ b/docs/wiz/MacOS_Other_Gui_Expecto_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_Fixie_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_Fixie_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_Fixie_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Fixie_None.md
+++ b/docs/wiz/MacOS_Other_Gui_Fixie_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_AppVeyor.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_AzureDevOps.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_GitHubActions.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_MSTest_None.md
+++ b/docs/wiz/MacOS_Other_Gui_MSTest_None.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_NUnit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_NUnit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_NUnit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_NUnit_None.md
+++ b/docs/wiz/MacOS_Other_Gui_NUnit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_TUnit_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_TUnit_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_TUnit_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_TUnit_None.md
+++ b/docs/wiz/MacOS_Other_Gui_TUnit_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_XunitV3_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_XunitV3_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_XunitV3_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_XunitV3_None.md
+++ b/docs/wiz/MacOS_Other_Gui_XunitV3_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/MacOS_Other_Gui_Xunit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Other_Gui_Xunit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/MacOS_Other_Gui_Xunit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Other_Gui_Xunit_None.md
+++ b/docs/wiz/MacOS_Other_Gui_Xunit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_Expecto_AppVeyor.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_Expecto_AzureDevOps.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_Expecto_GitHubActions.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Expecto_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_Expecto_None.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_Fixie_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_Fixie_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_Fixie_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Fixie_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_Fixie_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_MSTest_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_MSTest_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_MSTest_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_MSTest_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_MSTest_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_NUnit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_NUnit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_NUnit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_NUnit_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_NUnit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_TUnit_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_TUnit_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_TUnit_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_TUnit_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_TUnit_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_XunitV3_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_XunitV3_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_XunitV3_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_XunitV3_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_XunitV3_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Cli_Xunit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Cli_Xunit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Cli_Xunit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Cli_Xunit_None.md
+++ b/docs/wiz/MacOS_Rider_Cli_Xunit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_Expecto_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_Expecto_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_Expecto_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Expecto_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_Expecto_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_Fixie_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_Fixie_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_Fixie_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Fixie_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_Fixie_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_AppVeyor.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_AzureDevOps.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_GitHubActions.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_MSTest_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_MSTest_None.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_NUnit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_NUnit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_NUnit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_NUnit_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_NUnit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_TUnit_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_TUnit_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_TUnit_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_TUnit_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_TUnit_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_XunitV3_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_XunitV3_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_XunitV3_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_XunitV3_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_XunitV3_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/MacOS_Rider_Gui_Xunit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/MacOS_Rider_Gui_Xunit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/MacOS_Rider_Gui_Xunit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/MacOS_Rider_Gui_Xunit_None.md
+++ b/docs/wiz/MacOS_Rider_Gui_Xunit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_Expecto_AppVeyor.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_Expecto_AzureDevOps.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_Expecto_GitHubActions.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Expecto_None.md
+++ b/docs/wiz/Windows_Other_Cli_Expecto_None.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_Fixie_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_Fixie_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_Fixie_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Fixie_None.md
+++ b/docs/wiz/Windows_Other_Cli_Fixie_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_MSTest_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_MSTest_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_MSTest_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_MSTest_None.md
+++ b/docs/wiz/Windows_Other_Cli_MSTest_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_NUnit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_NUnit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_NUnit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_NUnit_None.md
+++ b/docs/wiz/Windows_Other_Cli_NUnit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_TUnit_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_TUnit_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_TUnit_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_TUnit_None.md
+++ b/docs/wiz/Windows_Other_Cli_TUnit_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_XunitV3_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_XunitV3_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_XunitV3_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_XunitV3_None.md
+++ b/docs/wiz/Windows_Other_Cli_XunitV3_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Cli_Xunit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Cli_Xunit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Cli_Xunit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Cli_Xunit_None.md
+++ b/docs/wiz/Windows_Other_Cli_Xunit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_Expecto_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_Expecto_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_Expecto_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Expecto_None.md
+++ b/docs/wiz/Windows_Other_Gui_Expecto_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_Fixie_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_Fixie_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_Fixie_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Fixie_None.md
+++ b/docs/wiz/Windows_Other_Gui_Fixie_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_AppVeyor.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_AzureDevOps.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_GitHubActions.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_Other_Gui_MSTest_None.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_NUnit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_NUnit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_NUnit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_NUnit_None.md
+++ b/docs/wiz/Windows_Other_Gui_NUnit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_TUnit_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_TUnit_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_TUnit_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_TUnit_None.md
+++ b/docs/wiz/Windows_Other_Gui_TUnit_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_XunitV3_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_XunitV3_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_XunitV3_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_XunitV3_None.md
+++ b/docs/wiz/Windows_Other_Gui_XunitV3_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_Other_Gui_Xunit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_Other_Gui_Xunit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_Other_Gui_Xunit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Other_Gui_Xunit_None.md
+++ b/docs/wiz/Windows_Other_Gui_Xunit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_Expecto_AppVeyor.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_Expecto_AzureDevOps.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_Expecto_GitHubActions.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Expecto_None.md
+++ b/docs/wiz/Windows_Rider_Cli_Expecto_None.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_Fixie_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_Fixie_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_Fixie_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Fixie_None.md
+++ b/docs/wiz/Windows_Rider_Cli_Fixie_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_MSTest_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_MSTest_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_MSTest_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_MSTest_None.md
+++ b/docs/wiz/Windows_Rider_Cli_MSTest_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_NUnit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_NUnit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_NUnit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_NUnit_None.md
+++ b/docs/wiz/Windows_Rider_Cli_NUnit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_TUnit_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_TUnit_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_TUnit_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_TUnit_None.md
+++ b/docs/wiz/Windows_Rider_Cli_TUnit_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_XunitV3_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_XunitV3_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_XunitV3_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_XunitV3_None.md
+++ b/docs/wiz/Windows_Rider_Cli_XunitV3_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Cli_Xunit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Cli_Xunit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Cli_Xunit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Cli_Xunit_None.md
+++ b/docs/wiz/Windows_Rider_Cli_Xunit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_Expecto_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_Expecto_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_Expecto_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Expecto_None.md
+++ b/docs/wiz/Windows_Rider_Gui_Expecto_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_Fixie_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_Fixie_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_Fixie_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Fixie_None.md
+++ b/docs/wiz/Windows_Rider_Gui_Fixie_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_AppVeyor.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_AzureDevOps.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_GitHubActions.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_Rider_Gui_MSTest_None.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_NUnit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_NUnit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_NUnit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_NUnit_None.md
+++ b/docs/wiz/Windows_Rider_Gui_NUnit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_TUnit_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_TUnit_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_TUnit_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_TUnit_None.md
+++ b/docs/wiz/Windows_Rider_Gui_TUnit_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_XunitV3_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_XunitV3_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_XunitV3_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_XunitV3_None.md
+++ b/docs/wiz/Windows_Rider_Gui_XunitV3_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_Rider_Gui_Xunit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_Rider_Gui_Xunit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_Rider_Gui_Xunit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_Rider_Gui_Xunit_None.md
+++ b/docs/wiz/Windows_Rider_Gui_Xunit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_AppVeyor.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_AzureDevOps.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_GitHubActions.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Expecto_None.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Fixie_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_MSTest_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_NUnit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_TUnit_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_XunitV3_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Cli_Xunit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Expecto_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Fixie_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AppVeyor.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_AzureDevOps.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_GitHubActions.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_MSTest_None.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_NUnit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_TUnit_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_XunitV3_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_None.md
+++ b/docs/wiz/Windows_VisualStudioWithReSharper_Gui_Xunit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Expecto_AppVeyor.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Expecto_AzureDevOps.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Expecto_GitHubActions.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Expecto_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Expecto_None.md
@@ -81,6 +81,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Fixie_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Fixie_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Fixie_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Fixie_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Fixie_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_MSTest_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_MSTest_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_MSTest_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_MSTest_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_NUnit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_NUnit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_NUnit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_NUnit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_NUnit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_TUnit_AppVeyor.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_TUnit_AzureDevOps.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_TUnit_GitHubActions.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_TUnit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_TUnit_None.md
@@ -80,6 +80,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_XunitV3_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_XunitV3_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_XunitV3_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_XunitV3_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_XunitV3_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Xunit_AppVeyor.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Xunit_AzureDevOps.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Xunit_GitHubActions.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Cli_Xunit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Cli_Xunit_None.md
@@ -82,6 +82,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Expecto_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Expecto_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Expecto_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Expecto_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Expecto_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Expecto_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Expecto_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Expecto_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Fixie_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Fixie_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Fixie_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Fixie_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Fixie_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Fixie_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Fixie_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Fixie_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_AppVeyor.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_AzureDevOps.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_GitHubActions.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_MSTest_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_MSTest_None.md
@@ -87,6 +87,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_NUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_NUnit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_NUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_NUnit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_NUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_NUnit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_NUnit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_NUnit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_TUnit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_TUnit_AppVeyor.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_TUnit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_TUnit_AzureDevOps.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_TUnit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_TUnit_GitHubActions.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_TUnit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_TUnit_None.md
@@ -86,6 +86,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_XunitV3_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_XunitV3_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_XunitV3_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_XunitV3_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_XunitV3_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_XunitV3_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_XunitV3_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_XunitV3_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Xunit_AppVeyor.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Xunit_AppVeyor.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Xunit_AzureDevOps.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Xunit_AzureDevOps.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Xunit_GitHubActions.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Xunit_GitHubActions.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/docs/wiz/Windows_VisualStudio_Gui_Xunit_None.md
+++ b/docs/wiz/Windows_VisualStudio_Gui_Xunit_None.md
@@ -88,6 +88,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/readme.md
+++ b/readme.md
@@ -642,6 +642,15 @@ eg add the following to `.gitattributes`
 ```
 
 
+#### Line ending autocrlf
+
+On Windows, if `core.autocrlf` is set to `true`, files may show as modified with no actual content changes. To fix this:
+
+```
+git config --global core.autocrlf input
+```
+
+
 #### EditorConfig settings
 
 If modifying text verified/received files in an editor, it is desirable for the editor to respect the above conventions. For [EditorConfig](https://editorconfig.org/) enabled the following can be used:

--- a/src/Verify/ConventionCheck/InnerVerifyChecks.cs
+++ b/src/Verify/ConventionCheck/InnerVerifyChecks.cs
@@ -172,6 +172,7 @@ public static class InnerVerifyChecks
 
         if (missing.Count == 0)
         {
+            CheckAutoCrlf();
             return;
         }
 
@@ -190,6 +191,44 @@ public static class InnerVerifyChecks
         }
 
         throw new VerifyCheckException(builder.ToString());
+    }
+
+    static void CheckAutoCrlf()
+    {
+        string? value;
+        var startInfo = new ProcessStartInfo("git", "config core.autocrlf")
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        try
+        {
+            using var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                return;
+            }
+
+            value = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit();
+        }
+        catch
+        {
+            // git not available
+            return;
+        }
+
+        if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new VerifyCheckException(
+                """
+                git `core.autocrlf` is set to `true`. This causes files to show as modified with no actual content changes when `eol=lf` is configured in .gitattributes.
+                To fix, run:
+
+                git config --global core.autocrlf input
+                """);
+        }
     }
 
     static string GetPath(string path) =>


### PR DESCRIPTION
Add documentation to README and docs about the Line ending autocrlf issue and recommend running `git config --global core.autocrlf input`. Implement CheckAutoCrlf in InnerVerifyChecks that runs `git config core.autocrlf`, and throw a VerifyCheckException with remediation guidance if the value is `true`. Invoke this check when other verify checks succeed to prevent files showing as modified due to CRLF handling when `.gitattributes` enforces LF.