### PR TITLE
Add parameterless ctor and overload priority

### DIFF
--- a/src/Verify/TempDirectory.cs
+++ b/src/Verify/TempDirectory.cs
@@ -121,7 +121,12 @@ public class TempDirectory :
     /// <exception cref="IOException">
     /// Thrown if the directory cannot be created (e.g., due to permissions or disk space).
     /// </exception>
-    public TempDirectory(bool ignoreLockedFiles = false)
+    public TempDirectory() : this(false)
+    {
+    }
+
+    [OverloadResolutionPriority(1)]
+    public TempDirectory(bool ignoreLockedFiles)
     {
         this.ignoreLockedFiles = ignoreLockedFiles;
         Path = IoPath.Combine(RootDirectory, IoPath.GetRandomFileName());


### PR DESCRIPTION
Introduce a parameterless TempDirectory() that delegates to the existing constructor, and mark the bool-taking constructor with [OverloadResolutionPriority(1)]. This adds a convenient default ctor while making the intended overload resolution explicit; no change to behavior beyond the added API surface.