### PR TITLE
ApplyForPropertyValue returns string instead of CharSpan

### DIFF
--- a/src/Verify/Serialization/CustomContractResolver_Dictionary.cs
+++ b/src/Verify/Serialization/CustomContractResolver_Dictionary.cs
@@ -100,7 +100,7 @@
                 return true;
             }
 
-            result = ApplyScrubbers.ApplyForPropertyValue(stringValue.AsSpan(), writer.settings, counter).ToString();
+            result = ApplyScrubbers.ApplyForPropertyValue(stringValue.AsSpan(), writer.settings, counter);
 
             return true;
         }

--- a/src/Verify/Serialization/Scrubbers/ApplyScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/ApplyScrubbers.cs
@@ -45,12 +45,12 @@ static class ApplyScrubbers
         target.FixNewlines();
     }
 
-    public static CharSpan ApplyForPropertyValue(CharSpan value, VerifySettings settings, Counter counter)
+    public static string ApplyForPropertyValue(CharSpan value, VerifySettings settings, Counter counter)
     {
         var builder = new StringBuilder(value.Length);
         builder.Append(value);
         ApplyForPropertyValue(settings, counter, builder);
-        return builder.AsSpan();
+        return builder.ToString();
     }
 
     public static void ApplyForPropertyValue(VerifySettings settings, Counter counter, StringBuilder builder)

--- a/src/Verify/Verifier/InnerVerifier_Xml.cs
+++ b/src/Verify/Verifier/InnerVerifier_Xml.cs
@@ -106,7 +106,7 @@ partial class InnerVerifier
             return result;
         }
 
-        return ApplyScrubbers.ApplyForPropertyValue(span, settings, counter).ToString();
+        return ApplyScrubbers.ApplyForPropertyValue(span, settings, counter);
     }
 
     void ScrubAttributes(XElement node, SerializationSettings serialization)
@@ -136,7 +136,7 @@ partial class InnerVerifier
             }
             else
             {
-                attribute.Value = ApplyScrubbers.ApplyForPropertyValue(span, settings, counter).ToString();
+                attribute.Value = ApplyScrubbers.ApplyForPropertyValue(span, settings, counter);
             }
         }
     }


### PR DESCRIPTION
  - Previously: builder.ToString().AsSpan() → callers then called .ToString() again = 2 string allocations
  - Now: builder.ToString() → callers use directly = 1 string allocation
  - Saves a full string copy at every call in InnerVerifier_Xml.cs (2 sites) and CustomContractResolver_Dictionary.cs (1 site)
  - The VerifyJsonWriter callers that use the result as CharSpan still work via implicit string → ReadOnlySpan<char> conversion