### PR TITLE
In-place sort instead of LINQ OrderByDescending

### DIFF
--- a/src/Verify/Serialization/Scrubbers/DirectoryReplacements_StringBuilder.cs
+++ b/src/Verify/Serialization/Scrubbers/DirectoryReplacements_StringBuilder.cs
@@ -39,11 +39,11 @@
 
         var matches = FindMatches(builder, paths);
 
-        // Sort by position descending
-        var orderByDescending = matches.OrderByDescending(_ => _.Index);
+        // Sort by position descending. In-place to avoid LINQ allocation
+        matches.Sort((a, b) => b.Index.CompareTo(a.Index));
 
         // Apply matches
-        foreach (var match in orderByDescending)
+        foreach (var match in matches)
         {
             builder.Overwrite(match.Value, match.Index, match.Length);
         }

--- a/src/Verify/Serialization/Scrubbers/GuidScrubber.cs
+++ b/src/Verify/Serialization/Scrubbers/GuidScrubber.cs
@@ -15,11 +15,11 @@
 
         var matches = FindMatches(builder, counter);
 
-        // Sort by position descending
-        var orderByDescending = matches.OrderByDescending(_ => _.Index);
+        // Sort by position descending. In-place to avoid LINQ allocation
+        matches.Sort((a, b) => b.Index.CompareTo(a.Index));
 
         // Apply matches
-        foreach (var match in orderByDescending)
+        foreach (var match in matches)
         {
             builder.Overwrite(match.Value, match.Index, 36);
         }

--- a/src/Verify/Serialization/Scrubbers/UserMachineScrubber_PerformReplacements.cs
+++ b/src/Verify/Serialization/Scrubbers/UserMachineScrubber_PerformReplacements.cs
@@ -12,11 +12,11 @@
 
         var matches = FindMatches(builder, find);
 
-        // Sort by position descending
-        var orderByDescending = matches.OrderByDescending(_ => _);
+        // Sort by position descending. In-place to avoid LINQ allocation
+        matches.Sort((a, b) => b.CompareTo(a));
 
         // Apply matches
-        foreach (var match in orderByDescending)
+        foreach (var match in matches)
         {
             builder.Overwrite(replace, match, find.Length);
         }


### PR DESCRIPTION
  - GuidScrubber.cs:19 — called on every GUID scrub operation
  - UserMachineScrubber_PerformReplacements.cs:16 — called on every user/machine scrub
  - DirectoryReplacements_StringBuilder.cs:43 — called on every directory replacement
  - Eliminates IOrderedEnumerable wrapper allocation + deferred execution overhead. List.Sort is in-place with zero allocation.