### PR TITLE
Remove unnecessary ToString() in VerifyJsonWriter

### DIFF
--- a/src/Verify/Serialization/VerifyJsonWriter.cs
+++ b/src/Verify/Serialization/VerifyJsonWriter.cs
@@ -54,7 +54,7 @@ public class VerifyJsonWriter :
             return;
         }
 
-        base.WriteRawValue(value.ToString());
+        base.WriteRawValue(value);
     }
 
     public void WriteRawValueWithScrubbers(string value) =>


### PR DESCRIPTION
Pass the value directly to base.WriteRawValue instead of calling value.ToString().