### PR TITLE
Strip solution dir prefix from XunitV3 attachment names

### DIFF
--- a/src/Verify.XunitV3.Tests/AttachmentTests.cs
+++ b/src/Verify.XunitV3.Tests/AttachmentTests.cs
@@ -1,6 +1,6 @@
 ﻿public class AttachmentTests
 {
-#if NET10_0
+#if NET11_0
     [Fact]
     public async Task Simple()
     {
@@ -10,10 +10,10 @@
         File.Delete(fullPath);
         await Verify("Foo").AutoVerify();
         File.Delete(fullPath);
-        var attachments = TestContext.Current.Attachments!;
-        Assert.Contains(attachments.Keys,
-            _ => _.Contains("Verify snapshot mismatch") &&
-                 _.Contains("AttachmentTests.Simple."));
+        var key = Assert.Single(TestContext.Current.Attachments!).Key;
+        Assert.StartsWith("Verify.XunitV3.Tests/AttachmentTests.Simple.", key);
+        Assert.EndsWith(".received.txt", key);
+        Assert.DoesNotContain(':', key);
     }
 
     [Fact]
@@ -37,10 +37,10 @@
             }
         }
 
-        var attachments = TestContext.Current.Attachments!;
-        Assert.Contains(attachments.Keys,
-            _ => _.Contains("Verify snapshot mismatch") &&
-                 _.Contains("AttachmentTests.Simple."));
+        var key = Assert.Single(TestContext.Current.Attachments!).Key;
+        Assert.StartsWith("Verify.XunitV3.Tests/AttachmentTests/AttachmentTests.Simple.", key);
+        Assert.EndsWith(".received.txt", key);
+        Assert.DoesNotContain(':', key);
     }
 #endif
 }

--- a/src/Verify.XunitV3/Verifier.cs
+++ b/src/Verify.XunitV3/Verifier.cs
@@ -5,8 +5,24 @@ public static partial class Verifier
 {
     static async Task AddFile(string path) =>
         TestContext.Current.AddAttachment(
-            $"Verify snapshot mismatch: {path}",
+            GetAttachmentName(path),
             await File.ReadAllBytesAsync(path));
+
+    internal static string GetAttachmentName(string path)
+    {
+        var fullPath = Path.GetFullPath(path).Replace('\\', '/');
+        var solutionDir = VerifierSettings.SolutionDir;
+        if (solutionDir is not null)
+        {
+            var fullSolutionDir = Path.GetFullPath(solutionDir).Replace('\\', '/').TrimEnd('/') + '/';
+            if (fullPath.StartsWith(fullSolutionDir, StringComparison.OrdinalIgnoreCase))
+            {
+                return fullPath[fullSolutionDir.Length..];
+            }
+        }
+
+        return fullPath;
+    }
 
     [ModuleInitializer]
     [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
  Previously attachment names were "Verify snapshot mismatch: {fullPath}"
  which contains a colon - invalid for GitHub Actions artifact upload on
  Windows-compatible file systems. Now emits the received file path
  relative to the solution directory, falling back to the full path when
  the solution dir is unknown.