### PR TITLE
Add TempDirectory + string operator for combining paths

### DIFF
--- a/docs/mdsource/temp-directory.source.md
+++ b/docs/mdsource/temp-directory.source.md
@@ -59,6 +59,13 @@ snippet: TempDirectoryDirectoryInfoConversion
 snippet: TempDirectoryInfoProperty
 
 
+### Combining paths
+
+A `TempDirectory` can be combined with a relative `string` suffix using the `+` operator. The directory path and suffix are joined with a single separator (an existing leading separator on the suffix is respected). The result is a `string`.
+
+snippet: TempDirectoryAddOperator
+
+
 ### TempDirectory RootDirectory Property
 
 Allows access to the root directory for all TempDirectory instances:

--- a/docs/temp-directory.md
+++ b/docs/temp-directory.md
@@ -146,6 +146,28 @@ public void InfoProperty()
 <!-- endSnippet -->
 
 
+### Combining paths
+
+A `TempDirectory` can be combined with a relative `string` suffix using the `+` operator. The directory path and suffix are joined with a single separator (an existing leading separator on the suffix is respected). The result is a `string`.
+
+<!-- snippet: TempDirectoryAddOperator -->
+<a id='snippet-TempDirectoryAddOperator'></a>
+```cs
+[Fact]
+public void AddOperatorUsage()
+{
+    using var temp = new TempDirectory();
+
+    // combine with a file name, joined by a single separator
+    var filePath = temp + "test.txt";
+
+    File.WriteAllText(filePath, "content");
+}
+```
+<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L280-L293' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryAddOperator' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+
 ### TempDirectory RootDirectory Property
 
 Allows access to the root directory for all TempDirectory instances:
@@ -191,7 +213,7 @@ public void IgnoreLockedFiles()
     Directory.Delete(path, true);
 }
 ```
-<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L340-L364' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryIgnoreLockedFiles' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L368-L392' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryIgnoreLockedFiles' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -255,7 +277,7 @@ public async Task BuildPath()
     });
 }
 ```
-<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L299-L319' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryBuildPath' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L327-L347' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryBuildPath' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -277,7 +299,7 @@ public async Task Scrubbing()
     });
 }
 ```
-<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L321-L336' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryScrubbing' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L349-L364' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryScrubbing' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result:
@@ -322,7 +344,7 @@ public void NoUsing()
     Debug.WriteLine(temp);
 }
 ```
-<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L282-L295' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryNoUsing' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L310-L323' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryNoUsing' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The directory can then be manually inspected.
@@ -346,7 +368,7 @@ public void OpenExplorerAndDebug()
     temp.OpenExplorerAndDebug();
 }
 ```
-<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L267-L280' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryOpenExplorerAndDebug' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/TempDirectoryTests.cs#L295-L308' title='Snippet source file'>snippet source</a> | <a href='#snippet-TempDirectoryOpenExplorerAndDebug' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This method is designed to help debug tests by enabling the inspection of the contents of the temporary directory while the test is paused. It performs two actions:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CA1822;CS1591;CS0649;xUnit1026;xUnit1013;CS1573;VerifyTestsProjectDir;VerifySetParameters;PolyFillTargetsForNuget;xUnit1051;NU1608;NU1109</NoWarn>
-    <Version>31.19.1</Version>
+    <Version>31.20.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>

--- a/src/Verify.Tests/TempDirectoryTests.cs
+++ b/src/Verify.Tests/TempDirectoryTests.cs
@@ -264,6 +264,34 @@ public class TempDirectoryTests
         Assert.Equal(temp.Path, temp.ToString());
     }
 
+    [Fact]
+    public void AddOperator()
+    {
+        using var directory = new TempDirectory();
+
+        var separator = Path.DirectorySeparatorChar;
+
+        Assert.Equal($"{directory.Path}{separator}test.txt", directory + "test.txt");
+        Assert.Equal($"{directory.Path}/test.txt", directory + "/test.txt");
+        Assert.Equal($"{directory.Path}\\test.txt", directory + "\\test.txt");
+        Assert.Equal(directory.Path, directory + "");
+    }
+
+    #region TempDirectoryAddOperator
+
+    [Fact]
+    public void AddOperatorUsage()
+    {
+        using var temp = new TempDirectory();
+
+        // combine with a file name, joined by a single separator
+        var filePath = temp + "test.txt";
+
+        File.WriteAllText(filePath, "content");
+    }
+
+    #endregion
+
     #region TempDirectoryOpenExplorerAndDebug
 
     [Fact(Explicit = true)]

--- a/src/Verify/TempDirectory.cs
+++ b/src/Verify/TempDirectory.cs
@@ -267,6 +267,24 @@ public class TempDirectory :
         new(temp.Path);
 
     /// <summary>
+    /// Combines the directory path with the relative <paramref name="suffix"/>, joined by a single separator.
+    /// </summary>
+    public static string operator +(TempDirectory directory, string suffix)
+    {
+        if (suffix.Length == 0)
+        {
+            return directory.Path;
+        }
+
+        if (suffix[0] is '/' or '\\')
+        {
+            return directory.Path + suffix;
+        }
+
+        return directory.Path + IoPath.DirectorySeparatorChar + suffix;
+    }
+
+    /// <summary>
     /// A <see cref="DirectoryInfo"/> represeting this instance.
     /// </summary>
     /// <example>


### PR DESCRIPTION
Only TempDirectory + relative string suffix is meaningful, since TempFile.Path and TempDirectory.Path are both full paths. Combining two full paths (or prepending to one) produces nonsense, so those overloads are omitted.