### PR TITLE
Throw for greedy RegisterFileConverter<object>

### DIFF
--- a/src/StaticSettingsTests/RegisterFileConverterTests.cs
+++ b/src/StaticSettingsTests/RegisterFileConverterTests.cs
@@ -1,0 +1,21 @@
+public class RegisterFileConverterTests :
+    BaseTest
+{
+    [Fact]
+    public void ObjectThrows()
+    {
+        var exception = Assert.Throws<Exception>(
+            () => VerifierSettings.RegisterFileConverter<object>(
+                (_, _) => new(null, "txt", "value")));
+        Assert.Contains("too greedy", exception.Message);
+    }
+
+    [Fact]
+    public void ObjectAsyncThrows()
+    {
+        var exception = Assert.Throws<Exception>(
+            () => VerifierSettings.RegisterFileConverter<object>(
+                (_, _) => Task.FromResult<ConversionResult>(new(null, "txt", "value"))));
+        Assert.Contains("too greedy", exception.Message);
+    }
+}

--- a/src/Verify/Splitters/Settings_Typed.cs
+++ b/src/Verify/Splitters/Settings_Typed.cs
@@ -26,6 +26,7 @@ public static partial class VerifierSettings
         CanConvert<T>? canConvert = null)
     {
         InnerVerifier.ThrowIfVerifyHasBeenRun();
+        ThrowIfObjectConverter<T>();
         RegisterFileConverter(
             (target, context) => Task.FromResult(conversion(target, context)),
             canConvert);
@@ -36,8 +37,17 @@ public static partial class VerifierSettings
         CanConvert<T>? canConvert = null)
     {
         InnerVerifier.ThrowIfVerifyHasBeenRun();
+        ThrowIfObjectConverter<T>();
         var converter = new TypeConverter((target, context) => conversion((T) target, context), DefaultCanConvert(canConvert));
         typedConverters.Add(converter);
+    }
+
+    static void ThrowIfObjectConverter<T>()
+    {
+        if (typeof(T) == typeof(object))
+        {
+            throw new("RegisterFileConverter<object> is too greedy since object matches all verified values. Instead use a more specific type, or use the non-generic RegisterFileConverter overload that takes an explicit `canConvert`.");
+        }
     }
 
     public static void RegisterFileConverter(


### PR DESCRIPTION
RegisterFileConverter<object> matches every verified value via the default `target is T` canConvert, silently hijacking all serialization. Guard the generic overloads and point users to a concrete type or the non-generic overload that requires an explicit canConvert.

Fixes #1656