### PR TITLE
Add visual image preview to snapshot comparer output

### DIFF
--- a/src/Verify.ExceptionParsing.Tests/VerifyExceptionMessageBuilderTests.SingleNotEqual_ImageWithMessage.verified.txt
+++ b/src/Verify.ExceptionParsing.Tests/VerifyExceptionMessageBuilderTests.SingleNotEqual_ImageWithMessage.verified.txt
@@ -1,0 +1,21 @@
+﻿Directory: {ProjectDirectory}
+NotEqual:
+  - Received: VerifyExceptionMessageBuilderTests.Fake.received.png
+    Verified: VerifyExceptionMessageBuilderTests.Fake.verified.png
+
+FileContent:
+
+NotEqual:
+
+Received: VerifyExceptionMessageBuilderTests.Fake.received.png
+Verified: VerifyExceptionMessageBuilderTests.Fake.verified.png
+Compare Result:
+PNG SSIM 0.9012 below threshold 0.9800.
+Visual:
+<div class="verify-image-preview">
+  <p><strong>Received</strong></p>
+  <img alt="Received snapshot" src="VerifyExceptionMessageBuilderTests.Fake.received.png" />
+  <p><strong>Verified</strong></p>
+  <img alt="Verified snapshot" src="VerifyExceptionMessageBuilderTests.Fake.verified.png" />
+</div>
+

--- a/src/Verify.ExceptionParsing.Tests/VerifyExceptionMessageBuilderTests.cs
+++ b/src/Verify.ExceptionParsing.Tests/VerifyExceptionMessageBuilderTests.cs
@@ -6,6 +6,8 @@ public class VerifyExceptionMessageBuilderTests
     static string fakeFilePrefix = CurrentFile.Relative("VerifyExceptionMessageBuilderTests.Fake");
     static string receivedBin = $"{fakeFilePrefix}.received.bin";
     static string verifiedBin = $"{fakeFilePrefix}.verified.bin";
+    static string receivedPng = $"{fakeFilePrefix}.received.png";
+    static string verifiedPng = $"{fakeFilePrefix}.verified.png";
     static string receivedTxt = $"{fakeFilePrefix}.received.txt";
     static string verifiedTxt = $"{fakeFilePrefix}.verified.txt";
     static string fakeReceivedTextFile = CurrentFile.Relative("VerifyExceptionMessageBuilderTests.Fake.received.txt");
@@ -76,6 +78,17 @@ public class VerifyExceptionMessageBuilderTests
             notEquals:
             [
                 new(new("bin", receivedBin, verifiedBin), "Binary files differ", null, null)
+            ],
+            delete: [],
+            equal: []);
+
+    [Fact]
+    public Task SingleNotEqual_ImageWithMessage() =>
+        BuildVerify(
+            @new: [],
+            notEquals:
+            [
+                new(new("png", receivedPng, verifiedPng), "PNG SSIM 0.9012 below threshold 0.9800.", null, null)
             ],
             delete: [],
             equal: []);

--- a/src/Verify/Verifier/VerifyExceptionMessageBuilder.cs
+++ b/src/Verify/Verifier/VerifyExceptionMessageBuilder.cs
@@ -1,5 +1,16 @@
 ﻿static class VerifyExceptionMessageBuilder
 {
+    static FrozenSet<string> previewableImageExtensions = new[]
+    {
+        "png",
+        "jpg",
+        "jpeg",
+        "gif",
+        "bmp",
+        "webp",
+        "svg"
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
     public static string Build(
         string directory,
         IReadOnlyCollection<NewResult> @new,
@@ -143,6 +154,23 @@
                  Compare Result:
                  {message}
                  """);
+
+            if (previewableImageExtensions.Contains(item.Extension))
+            {
+                builder.AppendLineN(
+                    $"""
+                     Visual:
+                     <div class="verify-image-preview">
+                       <p><strong>Received</strong></p>
+                       <img alt="Received snapshot" src="{ToHtmlPath(receivedPath)}" />
+                       <p><strong>Verified</strong></p>
+                       <img alt="Verified snapshot" src="{ToHtmlPath(verifiedPath)}" />
+                     </div>
+                     """);
+            }
         }
     }
+
+    static string ToHtmlPath(string path) =>
+        System.Net.WebUtility.HtmlEncode(path.Replace('\\', '/'));
 }


### PR DESCRIPTION
## Summary
- add image-specific visual preview markup to `VerifyExceptionMessageBuilder` when a comparer returns a message for a not-equal image file
- keep existing message format unchanged for non-image extensions
- add a new snapshot test case for PNG comparer message output

## Why
This makes snapshot failure output include renderable image markup so visual validation is possible directly from the emitted snapshot message.

## Test commands
- `$env:LOCALAPPDATA\\Microsoft\\dotnet\\dotnet.exe test src/Verify.ExceptionParsing.Tests/Verify.ExceptionParsing.Tests.csproj -c Release --no-restore`
- `$env:LOCALAPPDATA\\Microsoft\\dotnet\\dotnet.exe test src/Verify.Tests/Verify.Tests.csproj -c Release --no-restore -f net11.0 -- --filter-class PngSsimComparerTests`