### PR TITLE
Align received naming single tfm

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -211,11 +211,13 @@ Reference existing adapters like `Verify.Xunit/Verifier.cs` or `Verify.NUnit/Ver
 
 ### Accepting New Snapshots
 
-When tests fail, `.received.*` files are created showing actual output. To accept a new snapshot, copy the `.received.*` file to the corresponding `.verified.*` filename.
+When tests fail, `.received.*` files are created showing actual output. To accept a new snapshot, copy the `.received.*` file to the path on the `Verified:` line of the exception message. Do not derive the verified name from the received name — the two are not always the same.
 
-**Multi-target naming**: When a test project targets multiple frameworks, `.received.` files include a runtime suffix (e.g., `.DotNet11_0.received.txt`) but `.verified.` files do **not** (e.g., `.verified.txt`). When accepting snapshots, strip the runtime suffix from the filename.
+**Multi-target naming**: When a test project targets multiple frameworks (e.g., `Verify.Tests`), the `.received.` file always carries a runtime and version suffix (e.g., `.DotNet11_0.received.txt`). The `.verified.` file carries whatever `UniqueFor*` the test asked for, which may be nothing (`.verified.txt`), the runtime (`.DotNet.verified.txt`), or the same runtime and version (`.DotNet11_0.verified.txt`).
 
-**Single-target naming**: When a test project targets a single framework, the `.received.` file carries the same uniqueness as its `.verified.` file, including any `UniqueForRuntime`/`UniqueForRuntimeAndVersion` suffix. The two names match exactly, so accepting is a plain rename.
+**Single-target naming**: When a test project targets a single framework (e.g., `StaticSettingsTests`), the `.received.` file uses the same uniqueness as its `.verified.` file, including any `UniqueForRuntime`/`UniqueForRuntimeAndVersion` suffix.
+
+**Parameters**: Ignored parameters (`IgnoreParameters`, `IgnoreParametersForVerified`, `IgnoreConstructorParameters`) are kept in the `.received.` name and dropped from the `.verified.` name, regardless of how many frameworks are targeted.
 
 ### Debugging Tests
 

--- a/claude.md
+++ b/claude.md
@@ -215,6 +215,8 @@ When tests fail, `.received.*` files are created showing actual output. To accep
 
 **Multi-target naming**: When a test project targets multiple frameworks, `.received.` files include a runtime suffix (e.g., `.DotNet11_0.received.txt`) but `.verified.` files do **not** (e.g., `.verified.txt`). When accepting snapshots, strip the runtime suffix from the filename.
 
+**Single-target naming**: When a test project targets a single framework, the `.received.` file carries the same uniqueness as its `.verified.` file, including any `UniqueForRuntime`/`UniqueForRuntimeAndVersion` suffix. The two names match exactly, so accepting is a plain rename.
+
 ### Debugging Tests
 
 On CI (AppVeyor), failed test artifacts are uploaded for inspection.

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -82,7 +82,7 @@ Verified: TestClass.Method.verified.txt
 ## Rules
 
 - **Never hand-edit `.verified.*` files** to make tests pass. Always let Verify generate the correct output by running the test.
-- **Never derive the verified name from the received name.** The two are not always identical. When a test project targets multiple frameworks, the received file carries a runtime suffix (eg `TheTest.TheMethod.DotNet11_0.received.txt`) that the verified file does not (eg `TheTest.TheMethod.verified.txt`). Always take the destination from the `Verified:` line of the exception message.
+- **Never derive the verified name from the received name.** The two are not always identical. Multi-targeted projects add a runtime and version suffix to the received file, and ignored parameters are kept in the received name but dropped from the verified name. Always take the destination from the `Verified:` line of the exception message.
 - Snapshot files live next to the test source file. For a test in `Tests/MyTests.cs`, look for `Tests/MyTests.MethodName.verified.txt`.
 
 ## Scrubbed values
@@ -136,7 +136,7 @@ When a snapshot test fails:
    - **If expected**: copy the `.received.*` file to the `Verified:` path listed in the exception message to accept the new snapshot.
    - **If a bug**: fix the code, not the snapshot.
 4. Never hand-edit `.verified.*` files to make tests pass. Always let Verify generate the correct output by running the test.
-5. Never derive the verified name from the received name. The two are not always identical. When a test project targets multiple frameworks, the received file carries a runtime suffix (eg `TheTest.TheMethod.DotNet11_0.received.txt`) that the verified file does not (eg `TheTest.TheMethod.verified.txt`). Always take the destination from the `Verified:` line of the exception message.
+5. Never derive the verified name from the received name. The two are not always identical. Multi-targeted projects add a runtime and version suffix to the received file, and ignored parameters are kept in the received name but dropped from the verified name. Always take the destination from the `Verified:` line of the exception message.
 
 ### Scrubbed values
 

--- a/docs/ai-usage.md
+++ b/docs/ai-usage.md
@@ -75,13 +75,14 @@ Verified: TestClass.Method.verified.txt
 
 ### Step 3: Determine the action
 
-- **If the change is expected** (due to an intentional code change): copy the `.received.*` file over the `.verified.*` file to accept the new snapshot.
-- **If it is a new test** (no `.verified.*` file): accept the `.received.*` file as the new snapshot by renaming it to `.verified.*`.
+- **If the change is expected** (due to an intentional code change): copy the `.received.*` file to the `Verified:` path to accept the new snapshot.
+- **If it is a new test** (no `.verified.*` file): accept the `.received.*` file as the new snapshot by copying it to the `Verified:` path.
 - **If the change is a bug**: fix the code, not the snapshot. Re-run the test to confirm the fix.
 
 ## Rules
 
 - **Never hand-edit `.verified.*` files** to make tests pass. Always let Verify generate the correct output by running the test.
+- **Never derive the verified name from the received name.** The two are not always identical. When a test project targets multiple frameworks, the received file carries a runtime suffix (eg `TheTest.TheMethod.DotNet11_0.received.txt`) that the verified file does not (eg `TheTest.TheMethod.verified.txt`). Always take the destination from the `Verified:` line of the exception message.
 - Snapshot files live next to the test source file. For a test in `Tests/MyTests.cs`, look for `Tests/MyTests.MethodName.verified.txt`.
 
 ## Scrubbed values
@@ -132,9 +133,10 @@ When a snapshot test fails:
 1. Run the failing test and read the `.received.*` file that was generated.
 2. Compare it to the corresponding `.verified.*` file.
 3. Determine if the difference is expected (due to an intentional code change) or a bug.
-   - **If expected**: copy the `.received.*` file over the `.verified.*` file to accept the new snapshot, or delete the `.verified.*` file and rename the `.received.*` file.
+   - **If expected**: copy the `.received.*` file to the `Verified:` path listed in the exception message to accept the new snapshot.
    - **If a bug**: fix the code, not the snapshot.
 4. Never hand-edit `.verified.*` files to make tests pass. Always let Verify generate the correct output by running the test.
+5. Never derive the verified name from the received name. The two are not always identical. When a test project targets multiple frameworks, the received file carries a runtime suffix (eg `TheTest.TheMethod.DotNet11_0.received.txt`) that the verified file does not (eg `TheTest.TheMethod.verified.txt`). Always take the destination from the `Verified:` line of the exception message.
 
 ### Scrubbed values
 

--- a/docs/mdsource/ai-usage.source.md
+++ b/docs/mdsource/ai-usage.source.md
@@ -68,13 +68,14 @@ Verified: TestClass.Method.verified.txt
 
 ### Step 3: Determine the action
 
-- **If the change is expected** (due to an intentional code change): copy the `.received.*` file over the `.verified.*` file to accept the new snapshot.
-- **If it is a new test** (no `.verified.*` file): accept the `.received.*` file as the new snapshot by renaming it to `.verified.*`.
+- **If the change is expected** (due to an intentional code change): copy the `.received.*` file to the `Verified:` path to accept the new snapshot.
+- **If it is a new test** (no `.verified.*` file): accept the `.received.*` file as the new snapshot by copying it to the `Verified:` path.
 - **If the change is a bug**: fix the code, not the snapshot. Re-run the test to confirm the fix.
 
 ## Rules
 
 - **Never hand-edit `.verified.*` files** to make tests pass. Always let Verify generate the correct output by running the test.
+- **Never derive the verified name from the received name.** The two are not always identical. When a test project targets multiple frameworks, the received file carries a runtime suffix (eg `TheTest.TheMethod.DotNet11_0.received.txt`) that the verified file does not (eg `TheTest.TheMethod.verified.txt`). Always take the destination from the `Verified:` line of the exception message.
 - Snapshot files live next to the test source file. For a test in `Tests/MyTests.cs`, look for `Tests/MyTests.MethodName.verified.txt`.
 
 ## Scrubbed values
@@ -125,9 +126,10 @@ When a snapshot test fails:
 1. Run the failing test and read the `.received.*` file that was generated.
 2. Compare it to the corresponding `.verified.*` file.
 3. Determine if the difference is expected (due to an intentional code change) or a bug.
-   - **If expected**: copy the `.received.*` file over the `.verified.*` file to accept the new snapshot, or delete the `.verified.*` file and rename the `.received.*` file.
+   - **If expected**: copy the `.received.*` file to the `Verified:` path listed in the exception message to accept the new snapshot.
    - **If a bug**: fix the code, not the snapshot.
 4. Never hand-edit `.verified.*` files to make tests pass. Always let Verify generate the correct output by running the test.
+5. Never derive the verified name from the received name. The two are not always identical. When a test project targets multiple frameworks, the received file carries a runtime suffix (eg `TheTest.TheMethod.DotNet11_0.received.txt`) that the verified file does not (eg `TheTest.TheMethod.verified.txt`). Always take the destination from the `Verified:` line of the exception message.
 
 ### Scrubbed values
 

--- a/docs/mdsource/ai-usage.source.md
+++ b/docs/mdsource/ai-usage.source.md
@@ -75,7 +75,7 @@ Verified: TestClass.Method.verified.txt
 ## Rules
 
 - **Never hand-edit `.verified.*` files** to make tests pass. Always let Verify generate the correct output by running the test.
-- **Never derive the verified name from the received name.** The two are not always identical. When a test project targets multiple frameworks, the received file carries a runtime suffix (eg `TheTest.TheMethod.DotNet11_0.received.txt`) that the verified file does not (eg `TheTest.TheMethod.verified.txt`). Always take the destination from the `Verified:` line of the exception message.
+- **Never derive the verified name from the received name.** The two are not always identical. Multi-targeted projects add a runtime and version suffix to the received file, and ignored parameters are kept in the received name but dropped from the verified name. Always take the destination from the `Verified:` line of the exception message.
 - Snapshot files live next to the test source file. For a test in `Tests/MyTests.cs`, look for `Tests/MyTests.MethodName.verified.txt`.
 
 ## Scrubbed values
@@ -129,7 +129,7 @@ When a snapshot test fails:
    - **If expected**: copy the `.received.*` file to the `Verified:` path listed in the exception message to accept the new snapshot.
    - **If a bug**: fix the code, not the snapshot.
 4. Never hand-edit `.verified.*` files to make tests pass. Always let Verify generate the correct output by running the test.
-5. Never derive the verified name from the received name. The two are not always identical. When a test project targets multiple frameworks, the received file carries a runtime suffix (eg `TheTest.TheMethod.DotNet11_0.received.txt`) that the verified file does not (eg `TheTest.TheMethod.verified.txt`). Always take the destination from the `Verified:` line of the exception message.
+5. Never derive the verified name from the received name. The two are not always identical. Multi-targeted projects add a runtime and version suffix to the received file, and ignored parameters are kept in the received name but dropped from the verified name. Always take the destination from the `Verified:` line of the exception message.
 
 ### Scrubbed values
 

--- a/docs/mdsource/naming.source.md
+++ b/docs/mdsource/naming.source.md
@@ -322,7 +322,9 @@ eg. add the following to `.gitignore`
 
 ## Received and multi-targeting
 
-When a test project uses more than one `TargetFrameworks` (eg `<TargetFrameworks>net48;net7.0</TargetFrameworks>`) the runtime and version will be always be added as a uniqueness to the received file. This prevents file locking contention when the tests from both target framework run in parallel.
+When a test project uses more than one `TargetFrameworks` (eg `<TargetFrameworks>net48;net7.0</TargetFrameworks>`) the runtime and version will always be added as a uniqueness to the received file name. This prevents file locking contention when the tests from both target framework run in parallel.
+
+This applies to the default file naming. Under [UseUniqueDirectory](#useuniquedirectory) the received files use the same uniqueness as the verified files.
 
 
 ## Received and single-targeting

--- a/docs/mdsource/naming.source.md
+++ b/docs/mdsource/naming.source.md
@@ -325,6 +325,16 @@ eg. add the following to `.gitignore`
 When a test project uses more than one `TargetFrameworks` (eg `<TargetFrameworks>net48;net7.0</TargetFrameworks>`) the runtime and version will be always be added as a uniqueness to the received file. This prevents file locking contention when the tests from both target framework run in parallel.
 
 
+## Received and single-targeting
+
+When a test project uses a single `TargetFramework`, there is no such contention, so the received file uses the same uniqueness as the verified file. With `UniqueForRuntime` both files include the runtime:
+
+```
+TheTest.TheMethod.DotNet.received.txt
+TheTest.TheMethod.DotNet.verified.txt
+```
+
+
 ## Orphaned verified files
 
 One problem with Verify is there is currently no way to track or clean up orphaned verified files.

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -897,7 +897,9 @@ eg. add the following to `.gitignore`
 
 ## Received and multi-targeting
 
-When a test project uses more than one `TargetFrameworks` (eg `<TargetFrameworks>net48;net7.0</TargetFrameworks>`) the runtime and version will be always be added as a uniqueness to the received file. This prevents file locking contention when the tests from both target framework run in parallel.
+When a test project uses more than one `TargetFrameworks` (eg `<TargetFrameworks>net48;net7.0</TargetFrameworks>`) the runtime and version will always be added as a uniqueness to the received file name. This prevents file locking contention when the tests from both target framework run in parallel.
+
+This applies to the default file naming. Under [UseUniqueDirectory](#useuniquedirectory) the received files use the same uniqueness as the verified files.
 
 
 ## Received and single-targeting

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -900,6 +900,16 @@ eg. add the following to `.gitignore`
 When a test project uses more than one `TargetFrameworks` (eg `<TargetFrameworks>net48;net7.0</TargetFrameworks>`) the runtime and version will be always be added as a uniqueness to the received file. This prevents file locking contention when the tests from both target framework run in parallel.
 
 
+## Received and single-targeting
+
+When a test project uses a single `TargetFramework`, there is no such contention, so the received file uses the same uniqueness as the verified file. With `UniqueForRuntime` both files include the runtime:
+
+```
+TheTest.TheMethod.DotNet.received.txt
+TheTest.TheMethod.DotNet.verified.txt
+```
+
+
 ## Orphaned verified files
 
 One problem with Verify is there is currently no way to track or clean up orphaned verified files.

--- a/src/StaticSettingsTests/SingleTfmTests.cs
+++ b/src/StaticSettingsTests/SingleTfmTests.cs
@@ -20,4 +20,58 @@
             File.Delete(received);
         }
     }
+
+    // With a single target framework the received file carries the same uniqueness as the verified
+    // file, so the two names match and tooling can pair a received file with its verified file. When
+    // multiple frameworks are targeted the received file uses the runtime and version instead, which
+    // Verify.Tests covers via DanglingFiles.
+    [Fact]
+    public Task ReceivedUsesRuntime() =>
+        AssertReceivedIsSuffixed(
+            "SingleTfmTests.ReceivedUsesRuntime",
+            Namer.Runtime,
+            _ => _.UniqueForRuntime());
+
+    [Fact]
+    public Task ReceivedUsesRuntimeAndVersion() =>
+        AssertReceivedIsSuffixed(
+            "SingleTfmTests.ReceivedUsesRuntimeAndVersion",
+            Namer.RuntimeAndVersion,
+            _ => _.UniqueForRuntimeAndVersion());
+
+    [Fact]
+    public Task ReceivedUsesRuntimeForFileName() =>
+        AssertReceivedIsSuffixed(
+            "CustomFileName",
+            Namer.Runtime,
+            _ =>
+            {
+                _.UseFileName("CustomFileName");
+                _.UniqueForRuntime();
+            });
+
+    static async Task AssertReceivedIsSuffixed(string prefix, string suffix, Action<VerifySettings> configure)
+    {
+        var verified = CurrentFile.Relative($"{prefix}.{suffix}.verified.txt");
+        var received = CurrentFile.Relative($"{prefix}.{suffix}.received.txt");
+        var unsuffixed = CurrentFile.Relative($"{prefix}.received.txt");
+        File.Delete(verified);
+        File.Delete(received);
+        File.Delete(unsuffixed);
+        var settings = new VerifySettings();
+        settings.DisableDiff();
+        configure(settings);
+        try
+        {
+            await Assert.ThrowsAsync<VerifyException>(() => Verify("value", settings));
+            Assert.True(File.Exists(received));
+            Assert.False(File.Exists(unsuffixed));
+        }
+        finally
+        {
+            File.Delete(verified);
+            File.Delete(received);
+            File.Delete(unsuffixed);
+        }
+    }
 }

--- a/src/Verify/Verifier/InnerVerifier.cs
+++ b/src/Verify/Verifier/InnerVerifier.cs
@@ -338,6 +338,7 @@ public partial class InnerVerifier :
     // the concurrent runs of each framework do not overwrite each others received files. Otherwise
     // only one runtime is in play, so the received file can use the same uniqueness as the verified
     // file. Keeping the two aligned allows tooling to pair a received file with its verified file.
+    // Mutates sharedUniqueness, so GetUniquenessVerified, which takes a copy, has to be called first.
     static UniquenessList GetUniquenessReceived(UniquenessList sharedUniqueness, UniquenessList uniquenessVerified)
     {
         if (!VerifierSettings.TargetsMultipleFramework)

--- a/src/Verify/Verifier/InnerVerifier.cs
+++ b/src/Verify/Verifier/InnerVerifier.cs
@@ -306,22 +306,18 @@ public partial class InnerVerifier :
     {
         var sharedUniqueness = PrefixUnique.SharedUniqueness(namer);
         var uniquenessVerified = GetUniquenessVerified(sharedUniqueness, namer);
-
-        if (VerifierSettings.TargetsMultipleFramework)
-        {
-            sharedUniqueness.Add(Namer.RuntimeAndVersion);
-        }
+        var uniquenessReceived = GetUniquenessReceived(sharedUniqueness, uniquenessVerified);
 
         if (settings.FileName is not null)
         {
             return (
-                $"{settings.FileName}{sharedUniqueness}",
+                $"{settings.FileName}{uniquenessReceived}",
                 $"{settings.FileName}{uniquenessVerified}");
         }
 
         var receivedBuilder = new StringBuilder(typeAndMethod);
         receivedParameters?.Invoke(receivedBuilder);
-        receivedBuilder.Append(sharedUniqueness);
+        receivedBuilder.Append(uniquenessReceived);
         var receivedPrefix = receivedBuilder.ToString();
         if (settings.ignoreParametersForVerified)
         {
@@ -336,6 +332,21 @@ public partial class InnerVerifier :
         return (
             receivedPrefix,
             verifiedBuilder.ToString());
+    }
+
+    // When multiple frameworks are targeted, the received file uses the runtime and version, so that
+    // the concurrent runs of each framework do not overwrite each others received files. Otherwise
+    // only one runtime is in play, so the received file can use the same uniqueness as the verified
+    // file. Keeping the two aligned allows tooling to pair a received file with its verified file.
+    static UniquenessList GetUniquenessReceived(UniquenessList sharedUniqueness, UniquenessList uniquenessVerified)
+    {
+        if (!VerifierSettings.TargetsMultipleFramework)
+        {
+            return uniquenessVerified;
+        }
+
+        sharedUniqueness.Add(Namer.RuntimeAndVersion);
+        return sharedUniqueness;
     }
 
     static UniquenessList GetUniquenessVerified(UniquenessList sharedUniqueness, Namer namer)


### PR DESCRIPTION
Aligns the `.received.` file name with its `.verified.` file name for single-target-framework projects, and clarifies the naming rules in the docs and AI guidance.

## Background

`UniqueForRuntime`/`UniqueForRuntimeAndVersion` previously applied only to the verified name. On a single-TFM project that meant a mismatched pair:

```
WidgetTests.Render.received.txt          <- no runtime token
WidgetTests.Render.DotNet.verified.txt   <- runtime token
```

The two names could not be paired by name, which breaks external tooling that maps a received file to its verified file (e.g. review/accept tools). The received file now carries the same uniqueness as the verified file when a single framework is targeted.

Multi-TFM behaviour is deliberately unchanged: there the received file always keeps the runtime and version, so the parallel runs of each framework don't overwrite each other's received files.

## How received and verified names can diverge

Both names are built from the same template:

```
{TypeName.MethodName}  {parameters}  {uniqueness}  .received/.verified.{ext}
```

`TypeName.MethodName` and extension are always identical. Divergence comes from two independent axes, and a file can diverge on either or both at once:

- **Uniqueness** — the runtime token. *This is the axis this PR changed.*
- **Parameters** — the received name keeps parameters the verified name drops. *Pre-existing; unchanged here.*

Baseline for the examples: `class WidgetTests { Task Render() }` on **net11.0 / x64** → `Runtime` = `DotNet`, `RuntimeAndVersion` = `DotNet11_0`.

### Axis 1 — runtime uniqueness

The shared uniqueness (target-framework / assembly-config / architecture / OS-platform, if requested) is identical on both sides. The runtime token is what differs. Verified gets `DotNet` for `UniqueForRuntime`, `DotNet11_0` for `UniqueForRuntimeAndVersion`, nothing otherwise. Received on multi-TFM always gets `DotNet11_0`; on single-TFM it now matches verified.

| # | Project | Settings | received | verified | Match? |
|---|---|---|---|---|---|
| A1 | multi-TFM | (none) | `WidgetTests.Render.DotNet11_0.received.txt` | `WidgetTests.Render.verified.txt` | ✗ |
| A2 | multi-TFM | `UniqueForRuntime` | `WidgetTests.Render.DotNet11_0.received.txt` | `WidgetTests.Render.DotNet.verified.txt` | ✗ |
| A3 | multi-TFM | `UniqueForRuntimeAndVersion` | `WidgetTests.Render.DotNet11_0.received.txt` | `WidgetTests.Render.DotNet11_0.verified.txt` | ✓ |
| A4 | single-TFM | (none) | `WidgetTests.Render.received.txt` | `WidgetTests.Render.verified.txt` | ✓ |
| **A5** | **single-TFM** | **`UniqueForRuntime`** | *changed — see below* | `WidgetTests.Render.DotNet.verified.txt` | *changed* |
| **A6** | **single-TFM** | **`UniqueForRuntimeAndVersion`** | *changed — see below* | `WidgetTests.Render.DotNet11_0.verified.txt` | *changed* |

**A5 and A6 are the only rows this PR changes.** A1–A4 are byte-for-byte identical before and after.

```
A5  single-TFM + UniqueForRuntime
  BEFORE:  received  WidgetTests.Render.received.txt          verified  WidgetTests.Render.DotNet.verified.txt   ✗ mismatch
  AFTER:   received  WidgetTests.Render.DotNet.received.txt   verified  WidgetTests.Render.DotNet.verified.txt   ✓ match

A6  single-TFM + UniqueForRuntimeAndVersion
  BEFORE:  received  WidgetTests.Render.received.txt              verified  WidgetTests.Render.DotNet11_0.verified.txt   ✗ mismatch
  AFTER:   received  WidgetTests.Render.DotNet11_0.received.txt   verified  WidgetTests.Render.DotNet11_0.verified.txt   ✓ match
```

A2 is the nastiest surviving mismatch, and the reason "just strip the runtime suffix from the received name" is bad advice: received is `DotNet11_0`, verified is `DotNet` — not a suffix-strip apart.

### Axis 2 — parameters (unchanged by this PR)

Received always carries the full parameter set; verified may drop some or all. Using two parameters `size="large"`, `theme="dark"` (single-TFM, no `UniqueFor`):

| # | Settings | received | verified | Match? |
|---|---|---|---|---|
| B1 | normal params | `WidgetTests.Render_size=large_theme=dark.received.txt` | `WidgetTests.Render_size=large_theme=dark.verified.txt` | ✓ |
| B2 | `IgnoreParameters("size")` | `WidgetTests.Render_size=large_theme=dark.received.txt` | `WidgetTests.Render_theme=dark.verified.txt` | ✗ |
| B3 | `IgnoreParametersForVerified()` | `WidgetTests.Render_size=large_theme=dark.received.txt` | `WidgetTests.Render.verified.txt` | ✗ |
| B4 | `IgnoreConstructorParameters` | keeps ctor args | drops ctor args | ✗ |

B2 drops the named parameter only, B3 drops all of them, B4 drops the class-constructor args. `UseTextForParameters` applies the same text to both sides, so it never diverges.

### Both axes at once

They stack. E.g. multi-TFM + `IgnoreParameters("size")` (same before and after this PR):

```
received  WidgetTests.Render_size=large.DotNet11_0.received.txt
verified  WidgetTests.Render.verified.txt
```

## Takeaway

Received and verified names can differ by a runtime token and/or by dropped parameters, and the divergence is not a simple reversible transform. So the safe rule — reflected in the doc and AI-guidance changes here — is: don't reconstruct the verified name from the received name; read it off the `Verified:` line of the exception message. The behavioural half of this PR just removes one specific mismatch (single-TFM `UniqueForRuntime*`, rows A5/A6) so that case pairs by name.

## Changes

- `InnerVerifier.PrefixForFileConvention` — new `GetUniquenessReceived` helper: single-TFM received uses the verified uniqueness; multi-TFM unchanged.
- `SingleTfmTests` — three tests covering single-TFM `UniqueForRuntime`, `UniqueForRuntimeAndVersion`, and `UseFileName` + `UniqueForRuntime` (verified to fail without the fix).
- `docs/naming.md` — new "Received and single-targeting" section; the multi-targeting section notes the `UseUniqueDirectory` case.
- `docs/ai-usage.md` + `claude.md` — accept instructions point at the `Verified:` line rather than deriving the name; new rule covering the runtime-suffix and ignored-parameter divergences.
