### PR TITLE
Allow a stream target for a text extension

### DIFF
--- a/docs/converter.md
+++ b/docs/converter.md
@@ -184,6 +184,26 @@ Verify("the source text", "texttoconvert");
 <sup><a href='/src/Verify.Tests/Converters/ExtensionConverterTests.cs#L30-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-TextExtensionConverterVerify' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+A target for a text extension can also be built from a stream. The stream is read as text, so a converter can re-emit its source without converting it back to a string:
+
+<!-- snippet: RegisterStreamConverterTextExtensionStream -->
+<a id='snippet-RegisterStreamConverterTextExtensionStream'></a>
+```cs
+// A target for a text extension can be built from a stream, eg to re-emit the
+// source of the conversion. The stream is read as text.
+VerifierSettings.RegisterStreamConverter(
+    "streamtoconvert",
+    (_, stream, _) =>
+        new(
+            null,
+            [
+                new("streamtoconvert", stream),
+                new("txt", "derived from text")
+            ]));
+```
+<sup><a href='/src/Verify.Tests/Converters/ExtensionConverterTests.cs#L39-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-RegisterStreamConverterTextExtensionStream' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
 
 ### Cleanup
 

--- a/docs/mdsource/converter.source.md
+++ b/docs/mdsource/converter.source.md
@@ -62,6 +62,10 @@ snippet: RegisterStreamConverterTextExtension
 
 snippet: TextExtensionConverterVerify
 
+A target for a text extension can also be built from a stream. The stream is read as text, so a converter can re-emit its source without converting it back to a string:
+
+snippet: RegisterStreamConverterTextExtensionStream
+
 
 ### Cleanup
 

--- a/src/Verify.Tests/Converters/ExtensionConverterTests.TextSplitterStream.verified.streamtoconvert
+++ b/src/Verify.Tests/Converters/ExtensionConverterTests.TextSplitterStream.verified.streamtoconvert
@@ -1,0 +1,1 @@
+﻿the source text

--- a/src/Verify.Tests/Converters/ExtensionConverterTests.TextSplitterStream.verified.txt
+++ b/src/Verify.Tests/Converters/ExtensionConverterTests.TextSplitterStream.verified.txt
@@ -1,0 +1,1 @@
+﻿derived from text

--- a/src/Verify.Tests/Converters/ExtensionConverterTests.cs
+++ b/src/Verify.Tests/Converters/ExtensionConverterTests.cs
@@ -32,6 +32,33 @@
         #endregion
 
     [ModuleInitializer]
+    public static void TextSplitterStreamInit()
+    {
+        FileExtensions.AddTextExtension("streamtoconvert");
+
+        #region RegisterStreamConverterTextExtensionStream
+
+        // A target for a text extension can be built from a stream, eg to re-emit the
+        // source of the conversion. The stream is read as text.
+        VerifierSettings.RegisterStreamConverter(
+            "streamtoconvert",
+            (_, stream, _) =>
+                new(
+                    null,
+                    [
+                        new("streamtoconvert", stream),
+                        new("txt", "derived from text")
+                    ]));
+
+        #endregion
+    }
+
+    // a conversion splitter for a text extension that re-emits its source stream
+    [Fact]
+    public Task TextSplitterStream() =>
+        Verify("the source text", "streamtoconvert");
+
+    [ModuleInitializer]
     public static void RecursiveInit() =>
         VerifierSettings.RegisterStreamConverter(
             "recursive",

--- a/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.GetExtensions.verified.txt
+++ b/src/Verify.Tests/InnerVerifyChecksTests/VerifyChecksTests.GetExtensions.verified.txt
@@ -6,6 +6,7 @@
   nuspec,
   props,
   staticComparerExt,
+  streamtoconvert,
   texttoconvert,
   txt,
   xml

--- a/src/Verify/IoHelpers.cs
+++ b/src/Verify/IoHelpers.cs
@@ -160,6 +160,11 @@
     internal static async Task<StringBuilder> ReadStringBuilderWithFixedLines(TextReader reader)
     {
         var contents = await reader.ReadToEndAsync();
+        return contents.ToStringBuilderWithFixedLines();
+    }
+
+    internal static StringBuilder ToStringBuilderWithFixedLines(this string contents)
+    {
         var builder = new StringBuilder(contents);
         if (contents.Contains('\r'))
         {

--- a/src/Verify/Target.cs
+++ b/src/Verify/Target.cs
@@ -57,21 +57,29 @@ public readonly struct Target
     {
         Guards.AgainstBadExtension(extension);
 
-        if (FileExtensions.IsTextExtension(extension))
-        {
-            throw new(
-                $"""
-                 Don't pass a stream for text.
-                 If {extension} is not a text extension then use `FileExtensions.RemoveTextExtensions(\"{extension}\")` at initialization;
-                 Otherwise use `Target(string extension, string data)` or `Target(string extension, StringBuilder data, string? name)`.
-                 """);
-        }
-
         Extension = extension;
         Name = FileNameCleaner.SanitizeFilePath(name);
         PerformConversion = performConversion;
+
+        // text is always stored as text, so for a text extension the stream is read here.
+        // eg a converter registered against a text extension re-emitting its source stream.
+        if (FileExtensions.IsTextExtension(extension))
+        {
+            streamData = null;
+            stringBuilderData = ReadText(data);
+            return;
+        }
+
         streamData = data;
         stringBuilderData = null;
+    }
+
+    // the stream is owned by the target, so it is consumed here
+    static StringBuilder ReadText(Stream stream)
+    {
+        stream.MoveToStart();
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd().ToStringBuilderWithFixedLines();
     }
 
     public Target(string extension, StringBuilder data, string? name = null)


### PR DESCRIPTION
Since conversion splitters were allowed for text extensions (#1778), a converter registered against a text extension could still not re-emit its source: the Target stream constructor threw for text extensions. eg Verify.ImageMagick returns the svg alongside the rendered png.

The stream is now read as text, applying the same newline fixing already used when a stream is read into a text target.