### PR TITLE
Add GuidFormats option to ScrubInlineGuids

### DIFF
--- a/docs/guids.md
+++ b/docs/guids.md
@@ -139,6 +139,33 @@ public static class ModuleInitializer
 <!-- endSnippet -->
 
 
+### Limiting to specific formats
+
+By default both the `D` and `N` formats are scrubbed. To restrict scrubbing to specific formats, pass a `GuidFormats` value. This is useful for avoiding the scrubbing of 32 character hex content (an MD5 hash for example) that would otherwise match the `N` format:
+
+<!-- snippet: ScrubInlineGuidsDashedOnly -->
+<a id='snippet-ScrubInlineGuidsDashedOnly'></a>
+```cs
+// Only the "D" format is scrubbed. The 32 char hex hash is left untouched.
+[Fact]
+public Task ScrubInlineGuidsDashedOnly() =>
+    Verify("guid: 173535ae-995b-4cc6-a74e-8cd4be57039c hash: 5d41402abc4b2a76b9719d911017c592")
+        .ScrubInlineGuids(GuidFormats.Dashed);
+```
+<sup><a href='/src/Verify.Tests/GuidScrubberTests.cs#L126-L134' title='Snippet source file'>snippet source</a> | <a href='#snippet-ScrubInlineGuidsDashedOnly' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Results in the following, where the `D` format Guid is scrubbed but the hash is left untouched:
+
+<!-- snippet: GuidScrubberTests.ScrubInlineGuidsDashedOnly.verified.txt -->
+<a id='snippet-GuidScrubberTests.ScrubInlineGuidsDashedOnly.verified.txt'></a>
+```txt
+guid: Guid_1 hash: 5d41402abc4b2a76b9719d911017c592
+```
+<sup><a href='/src/Verify.Tests/GuidScrubberTests.ScrubInlineGuidsDashedOnly.verified.txt#L1-L1' title='Snippet source file'>snippet source</a> | <a href='#snippet-GuidScrubberTests.ScrubInlineGuidsDashedOnly.verified.txt' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+
 ## Named Guid
 
 Specific Guids can be named. When any of those Guids are found, it will be replaced with the supplied name.
@@ -184,7 +211,7 @@ public Task NamedGuidFluent()
         .AddNamedGuid(guid, "instanceNamed");
 }
 ```
-<sup><a href='/src/Verify.Tests/GuidScrubberTests.cs#L126-L140' title='Snippet source file'>snippet source</a> | <a href='#snippet-NamedGuidFluent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/GuidScrubberTests.cs#L142-L156' title='Snippet source file'>snippet source</a> | <a href='#snippet-NamedGuidFluent' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -219,7 +246,7 @@ public Task InferredNamedGuidFluent()
         .AddNamedGuid(namedGuid);
 }
 ```
-<sup><a href='/src/Verify.Tests/GuidScrubberTests.cs#L142-L156' title='Snippet source file'>snippet source</a> | <a href='#snippet-InferredNamedGuidFluent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/GuidScrubberTests.cs#L158-L172' title='Snippet source file'>snippet source</a> | <a href='#snippet-InferredNamedGuidFluent' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Result: 

--- a/docs/mdsource/guids.source.md
+++ b/docs/mdsource/guids.source.md
@@ -51,6 +51,17 @@ snippet: ScrubInlineGuidsFluent
 snippet: ScrubInlineGuidsGlobal
 
 
+### Limiting to specific formats
+
+By default both the `D` and `N` formats are scrubbed. To restrict scrubbing to specific formats, pass a `GuidFormats` value. This is useful for avoiding the scrubbing of 32 character hex content (an MD5 hash for example) that would otherwise match the `N` format:
+
+snippet: ScrubInlineGuidsDashedOnly
+
+Results in the following, where the `D` format Guid is scrubbed but the hash is left untouched:
+
+snippet: GuidScrubberTests.ScrubInlineGuidsDashedOnly.verified.txt
+
+
 ## Named Guid
 
 Specific Guids can be named. When any of those Guids are found, it will be replaced with the supplied name.

--- a/src/Verify.Tests/GuidScrubberTests.ScrubInlineGuidsDashedOnly.verified.txt
+++ b/src/Verify.Tests/GuidScrubberTests.ScrubInlineGuidsDashedOnly.verified.txt
@@ -1,0 +1,1 @@
+﻿guid: Guid_1 hash: 5d41402abc4b2a76b9719d911017c592

--- a/src/Verify.Tests/GuidScrubberTests.ScrubInlineGuidsUndashedOnly.verified.txt
+++ b/src/Verify.Tests/GuidScrubberTests.ScrubInlineGuidsUndashedOnly.verified.txt
@@ -1,0 +1,1 @@
+﻿guid: 173535ae-995b-4cc6-a74e-8cd4be57039c hash: Guid_1

--- a/src/Verify.Tests/GuidScrubberTests.cs
+++ b/src/Verify.Tests/GuidScrubberTests.cs
@@ -123,6 +123,22 @@ public class GuidScrubberTests
         Verify("value: c8eeaf99d5c4434185434597c3fd40c9")
             .ScrubInlineGuids();
 
+    #region ScrubInlineGuidsDashedOnly
+
+    // Only the "D" format is scrubbed. The 32 char hex hash is left untouched.
+    [Fact]
+    public Task ScrubInlineGuidsDashedOnly() =>
+        Verify("guid: 173535ae-995b-4cc6-a74e-8cd4be57039c hash: 5d41402abc4b2a76b9719d911017c592")
+            .ScrubInlineGuids(GuidFormats.Dashed);
+
+    #endregion
+
+    // Only the "N" format is scrubbed. The "D" format guid is left untouched.
+    [Fact]
+    public Task ScrubInlineGuidsUndashedOnly() =>
+        Verify("guid: 173535ae-995b-4cc6-a74e-8cd4be57039c hash: 5d41402abc4b2a76b9719d911017c592")
+            .ScrubInlineGuids(GuidFormats.Undashed);
+
     #region NamedGuidFluent
 
     [Fact]

--- a/src/Verify/Serialization/Scrubbers/GuidFormats.cs
+++ b/src/Verify/Serialization/Scrubbers/GuidFormats.cs
@@ -1,0 +1,26 @@
+namespace VerifyTests;
+
+/// <summary>
+/// The <see cref="Guid" /> formats that <see cref="VerifySettings.ScrubInlineGuids(GuidFormats)" /> matches.
+/// </summary>
+[Flags]
+public enum GuidFormats
+{
+    /// <summary>
+    /// The "D" format: 32 hex digits separated by hyphens (e.g. <c>00000000-0000-0000-0000-000000000000</c>).
+    /// The "B" and "P" formats are covered by this since they wrap the "D" format in delimiters.
+    /// </summary>
+    Dashed = 1,
+
+    /// <summary>
+    /// The "N" format: 32 hex digits with no separators (e.g. <c>00000000000000000000000000000000</c>).
+    /// Note that any 32 character hex sequence (an MD5 hash for example) is a valid "N" format Guid, so
+    /// content of that exact length will also be scrubbed.
+    /// </summary>
+    Undashed = 2,
+
+    /// <summary>
+    /// Both <see cref="Dashed" /> and <see cref="Undashed" />.
+    /// </summary>
+    All = Dashed | Undashed
+}

--- a/src/Verify/Serialization/Scrubbers/GuidMatcher.cs
+++ b/src/Verify/Serialization/Scrubbers/GuidMatcher.cs
@@ -26,6 +26,20 @@ static class GuidMatcher
         static counter => counter.ScrubGuids,
         requireWordBoundary: true);
 
+    // The scrubbers for the requested formats, in the order they should be applied.
+    public static IEnumerable<Scrubber> ForFormats(GuidFormats formats)
+    {
+        if ((formats & GuidFormats.Dashed) != 0)
+        {
+            yield return Instance;
+        }
+
+        if ((formats & GuidFormats.Undashed) != 0)
+        {
+            yield return NInstance;
+        }
+    }
+
     static string? Match(CharSpan window, Counter counter, IReadOnlyDictionary<string, object> context)
     {
         // Cheap prefilter: the "D" format has dashes at fixed offsets

--- a/src/Verify/Serialization/Scrubbers/VerifierSettings_ExtensionMappedGlobalScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifierSettings_ExtensionMappedGlobalScrubbers.cs
@@ -90,10 +90,14 @@ public static partial class VerifierSettings
     /// <summary>
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
-    public static void ScrubInlineGuids(string extension)
+    /// <param name="extension">The file extension to apply the scrubber to.</param>
+    /// <param name="formats">The <see cref="Guid" /> formats to match. Defaults to <see cref="GuidFormats.All" />.</param>
+    public static void ScrubInlineGuids(string extension, GuidFormats formats = GuidFormats.All)
     {
-        AddScrubber(extension, GuidMatcher.Instance);
-        AddScrubber(extension, GuidMatcher.NInstance);
+        foreach (var scrubber in GuidMatcher.ForFormats(formats))
+        {
+            AddScrubber(extension, scrubber);
+        }
     }
 
     /// <summary>

--- a/src/Verify/Serialization/Scrubbers/VerifierSettings_ExtensionMappedGlobalScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifierSettings_ExtensionMappedGlobalScrubbers.cs
@@ -91,8 +91,15 @@ public static partial class VerifierSettings
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
     /// <param name="extension">The file extension to apply the scrubber to.</param>
-    /// <param name="formats">The <see cref="Guid" /> formats to match. Defaults to <see cref="GuidFormats.All" />.</param>
-    public static void ScrubInlineGuids(string extension, GuidFormats formats = GuidFormats.All)
+    public static void ScrubInlineGuids(string extension) =>
+        ScrubInlineGuids(extension, GuidFormats.All);
+
+    /// <summary>
+    /// Replace inline <see cref="Guid" />s with a placeholder.
+    /// </summary>
+    /// <param name="extension">The file extension to apply the scrubber to.</param>
+    /// <param name="formats">The <see cref="Guid" /> formats to match.</param>
+    public static void ScrubInlineGuids(string extension, GuidFormats formats)
     {
         foreach (var scrubber in GuidMatcher.ForFormats(formats))
         {

--- a/src/Verify/Serialization/Scrubbers/VerifierSettings_GlobalScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifierSettings_GlobalScrubbers.cs
@@ -127,10 +127,13 @@ public static partial class VerifierSettings
     /// <summary>
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
-    public static void ScrubInlineGuids()
+    /// <param name="formats">The <see cref="Guid" /> formats to match. Defaults to <see cref="GuidFormats.All" />.</param>
+    public static void ScrubInlineGuids(GuidFormats formats = GuidFormats.All)
     {
-        AddScrubber(GuidMatcher.Instance);
-        AddScrubber(GuidMatcher.NInstance);
+        foreach (var scrubber in GuidMatcher.ForFormats(formats))
+        {
+            AddScrubber(scrubber);
+        }
     }
 
     /// <summary>

--- a/src/Verify/Serialization/Scrubbers/VerifierSettings_GlobalScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifierSettings_GlobalScrubbers.cs
@@ -127,8 +127,14 @@ public static partial class VerifierSettings
     /// <summary>
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
-    /// <param name="formats">The <see cref="Guid" /> formats to match. Defaults to <see cref="GuidFormats.All" />.</param>
-    public static void ScrubInlineGuids(GuidFormats formats = GuidFormats.All)
+    public static void ScrubInlineGuids() =>
+        ScrubInlineGuids(GuidFormats.All);
+
+    /// <summary>
+    /// Replace inline <see cref="Guid" />s with a placeholder.
+    /// </summary>
+    /// <param name="formats">The <see cref="Guid" /> formats to match.</param>
+    public static void ScrubInlineGuids(GuidFormats formats)
     {
         foreach (var scrubber in GuidMatcher.ForFormats(formats))
         {

--- a/src/Verify/Serialization/Scrubbers/VerifySettings_ExtensionMappedInstanceScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifySettings_ExtensionMappedInstanceScrubbers.cs
@@ -78,10 +78,14 @@ public partial class VerifySettings
     /// <summary>
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
-    public void ScrubInlineGuids(string extension)
+    /// <param name="extension">The file extension to apply the scrubber to.</param>
+    /// <param name="formats">The <see cref="Guid" /> formats to match. Defaults to <see cref="GuidFormats.All" />.</param>
+    public void ScrubInlineGuids(string extension, GuidFormats formats = GuidFormats.All)
     {
-        AddScrubber(extension, GuidMatcher.Instance);
-        AddScrubber(extension, GuidMatcher.NInstance);
+        foreach (var scrubber in GuidMatcher.ForFormats(formats))
+        {
+            AddScrubber(extension, scrubber);
+        }
     }
 
     /// <summary>

--- a/src/Verify/Serialization/Scrubbers/VerifySettings_ExtensionMappedInstanceScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifySettings_ExtensionMappedInstanceScrubbers.cs
@@ -79,8 +79,15 @@ public partial class VerifySettings
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
     /// <param name="extension">The file extension to apply the scrubber to.</param>
-    /// <param name="formats">The <see cref="Guid" /> formats to match. Defaults to <see cref="GuidFormats.All" />.</param>
-    public void ScrubInlineGuids(string extension, GuidFormats formats = GuidFormats.All)
+    public void ScrubInlineGuids(string extension) =>
+        ScrubInlineGuids(extension, GuidFormats.All);
+
+    /// <summary>
+    /// Replace inline <see cref="Guid" />s with a placeholder.
+    /// </summary>
+    /// <param name="extension">The file extension to apply the scrubber to.</param>
+    /// <param name="formats">The <see cref="Guid" /> formats to match.</param>
+    public void ScrubInlineGuids(string extension, GuidFormats formats)
     {
         foreach (var scrubber in GuidMatcher.ForFormats(formats))
         {

--- a/src/Verify/Serialization/Scrubbers/VerifySettings_InstanceScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifySettings_InstanceScrubbers.cs
@@ -85,15 +85,18 @@ public partial class VerifySettings
     /// <summary>
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
-    public void ScrubInlineGuids()
+    /// <param name="formats">The <see cref="Guid" /> formats to match. Defaults to <see cref="GuidFormats.All" />.</param>
+    public void ScrubInlineGuids(GuidFormats formats = GuidFormats.All)
     {
         if (serialization.ScrubGuids == false)
         {
             throw new("ScrubGuids is disabled. Call .ScrubGuids() before calling .ScrubInlineGuids().");
         }
 
-        AddScrubber(GuidMatcher.Instance);
-        AddScrubber(GuidMatcher.NInstance);
+        foreach (var scrubber in GuidMatcher.ForFormats(formats))
+        {
+            AddScrubber(scrubber);
+        }
     }
 
     /// <summary>

--- a/src/Verify/Serialization/Scrubbers/VerifySettings_InstanceScrubbers.cs
+++ b/src/Verify/Serialization/Scrubbers/VerifySettings_InstanceScrubbers.cs
@@ -85,8 +85,14 @@ public partial class VerifySettings
     /// <summary>
     /// Replace inline <see cref="Guid" />s with a placeholder.
     /// </summary>
-    /// <param name="formats">The <see cref="Guid" /> formats to match. Defaults to <see cref="GuidFormats.All" />.</param>
-    public void ScrubInlineGuids(GuidFormats formats = GuidFormats.All)
+    public void ScrubInlineGuids() =>
+        ScrubInlineGuids(GuidFormats.All);
+
+    /// <summary>
+    /// Replace inline <see cref="Guid" />s with a placeholder.
+    /// </summary>
+    /// <param name="formats">The <see cref="Guid" /> formats to match.</param>
+    public void ScrubInlineGuids(GuidFormats formats)
     {
         if (serialization.ScrubGuids == false)
         {

--- a/src/Verify/SettingsTask_Scrubbing.cs
+++ b/src/Verify/SettingsTask_Scrubbing.cs
@@ -42,9 +42,17 @@ public partial class SettingsTask
         return this;
     }
 
+    /// <inheritdoc cref="VerifySettings.ScrubInlineGuids()"/>
+    [Pure]
+    public SettingsTask ScrubInlineGuids()
+    {
+        CurrentSettings.ScrubInlineGuids();
+        return this;
+    }
+
     /// <inheritdoc cref="VerifySettings.ScrubInlineGuids(GuidFormats)"/>
     [Pure]
-    public SettingsTask ScrubInlineGuids(GuidFormats formats = GuidFormats.All)
+    public SettingsTask ScrubInlineGuids(GuidFormats formats)
     {
         CurrentSettings.ScrubInlineGuids(formats);
         return this;
@@ -66,9 +74,17 @@ public partial class SettingsTask
         return this;
     }
 
+    /// <inheritdoc cref="VerifySettings.ScrubInlineGuids(string)"/>
+    [Pure]
+    public SettingsTask ScrubInlineGuids(string extension)
+    {
+        CurrentSettings.ScrubInlineGuids(extension);
+        return this;
+    }
+
     /// <inheritdoc cref="VerifySettings.ScrubInlineGuids(string,GuidFormats)"/>
     [Pure]
-    public SettingsTask ScrubInlineGuids(string extension, GuidFormats formats = GuidFormats.All)
+    public SettingsTask ScrubInlineGuids(string extension, GuidFormats formats)
     {
         CurrentSettings.ScrubInlineGuids(extension, formats);
         return this;

--- a/src/Verify/SettingsTask_Scrubbing.cs
+++ b/src/Verify/SettingsTask_Scrubbing.cs
@@ -42,11 +42,11 @@ public partial class SettingsTask
         return this;
     }
 
-    /// <inheritdoc cref="VerifySettings.ScrubInlineGuids()"/>
+    /// <inheritdoc cref="VerifySettings.ScrubInlineGuids(GuidFormats)"/>
     [Pure]
-    public SettingsTask ScrubInlineGuids()
+    public SettingsTask ScrubInlineGuids(GuidFormats formats = GuidFormats.All)
     {
-        CurrentSettings.ScrubInlineGuids();
+        CurrentSettings.ScrubInlineGuids(formats);
         return this;
     }
 
@@ -66,11 +66,11 @@ public partial class SettingsTask
         return this;
     }
 
-    /// <inheritdoc cref="VerifySettings.ScrubInlineGuids(string)"/>
+    /// <inheritdoc cref="VerifySettings.ScrubInlineGuids(string,GuidFormats)"/>
     [Pure]
-    public SettingsTask ScrubInlineGuids(string extension)
+    public SettingsTask ScrubInlineGuids(string extension, GuidFormats formats = GuidFormats.All)
     {
-        CurrentSettings.ScrubInlineGuids(extension);
+        CurrentSettings.ScrubInlineGuids(extension, formats);
         return this;
     }
 


### PR DESCRIPTION
Fixes #1822

## Problem

`ScrubInlineGuids` matches both `D` format (`00000000-0000-0000-0000-000000000000`) and `N` format (`00000000000000000000000000000000`) guids. Since any 32 character hex sequence is a valid `N` format guid, hex content of that exact length (an MD5 hash for example) is also scrubbed. There was no way to opt out of `N` matching while keeping `D`.

## Change

Add a `GuidFormats` flags enum and new `ScrubInlineGuids` overloads that accept it:

```csharp
// Only scrub dashed "D" format guids; 32 char hex hashes are left untouched
.ScrubInlineGuids(GuidFormats.Dashed)
```

- `GuidFormats` = `Dashed` (the `D` format, which also covers `B`/`P`) | `Undashed` (the `N` format) | `All`.
- The existing parameterless / extension-only signatures are **left untouched**; the format selection is exposed as **added overloads** rather than an optional parameter, so this is not a binary breaking change (an optional parameter would change the existing method signatures and break callers compiled against them with `MissingMethodException`).
- Applied consistently across all entry points: instance / global × plain / extension-mapped, plus the fluent `SettingsTask` wrappers. A shared `GuidMatcher.ForFormats` helper preserves the existing `D`-then-`N` scrubber order, and the original methods now delegate to `GuidFormats.All`.

## Tests & docs

- Added tests proving `GuidFormats.Dashed` leaves an `N` format hash untouched, and `GuidFormats.Undashed` leaves a `D` format guid untouched.
- Documented the new option in `docs/mdsource/guids.source.md` and regenerated `docs/guids.md`.
