### PR TITLE
Use a decimal literal for the decimal test data

### DIFF
--- a/src/Verify.Tests/SimpleTypeTests.cs
+++ b/src/Verify.Tests/SimpleTypeTests.cs
@@ -103,7 +103,7 @@
         yield return [(uint) 1];
         yield return [(ulong) 1];
         yield return [(ushort) 1];
-        yield return [(decimal) 1.1];
+        yield return [1.1m];
         yield return [(float) 1.1];
         yield return [new Guid("ebced679-45d3-4653-8791-3d969c4a986c")];
         yield return [new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Utc).ToUniversalTime()];

--- a/src/Verify.XunitV3.Tests/Snippets/ParametersSample.cs
+++ b/src/Verify.XunitV3.Tests/Snippets/ParametersSample.cs
@@ -4,7 +4,7 @@ public class ParametersSample
     {
         yield return
         [
-            (decimal) 1.1
+            1.1m
         ];
     }
 


### PR DESCRIPTION
(decimal) 1.1 casts the double literal 1.1, and .NET 11 changed that conversion to preserve full precision rather than rounding to 15 significant digits, so the value became 1.1000000000000000888178419700. The cast is constant folded, so the new value reached every target framework, and SimpleTypeTests.Run and ParametersSample.Decimal failed on all of them.

Both tests are about serializing a decimal, not about the double to decimal conversion, so 1.1m is the value they meant. It also keeps the parameter in the verified file name as 1.1, which accepting the new output would have renamed.