### PR TITLE
Format UTC offsets with invariant culture

### DIFF
--- a/docs/type-to-string-mapping.md
+++ b/docs/type-to-string-mapping.md
@@ -275,20 +275,20 @@ public static partial class DateFormatter
         {
             if (offset.Minutes == 0)
             {
-                return $"+{offset.TotalHours:0}";
+                return $"+{offset.TotalHours.ToString("0", Culture.InvariantCulture)}";
             }
 
-            return $"+{offset.Hours:0}-{offset.Minutes:00}";
+            return $"+{offset.Hours.ToString("0", Culture.InvariantCulture)}-{offset.Minutes.ToString("00", Culture.InvariantCulture)}";
         }
 
         if (offset < TimeSpan.Zero)
         {
             if (offset.Minutes == 0)
             {
-                return $"{offset.Hours:0}";
+                return offset.Hours.ToString("0", Culture.InvariantCulture);
             }
 
-            return $"{offset.Hours:0}{offset.Minutes:00}";
+            return $"{offset.Hours.ToString("0", Culture.InvariantCulture)}{offset.Minutes.ToString("00", Culture.InvariantCulture)}";
         }
 
         return "+0";

--- a/src/Verify.Tests/DateFormatterTests.cs
+++ b/src/Verify.Tests/DateFormatterTests.cs
@@ -194,6 +194,36 @@
         });
     }
 
+    [Fact]
+    public void OffsetIsNotAffectedByCurrentCulture()
+    {
+        // some cultures (for example ar-SA) use a negative sign that is not "-"
+        var culture = (CultureInfo) CultureInfo.InvariantCulture.Clone();
+        culture.NumberFormat.NegativeSign = "!";
+
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = culture;
+
+            var negativeHalfHour = new DateTimeOffset(2000, 10, 1, 0, 0, 0, TimeSpan.FromHours(-1.5));
+            Assert.Equal("2000-10-01 -1-30", DateFormatter.Convert(negativeHalfHour));
+            Assert.Equal("2000-10-01-1-30", DateFormatter.ToParameterString(negativeHalfHour));
+
+            var negativeWholeHour = new DateTimeOffset(2000, 10, 1, 0, 0, 0, TimeSpan.FromHours(-5));
+            Assert.Equal("2000-10-01 -5", DateFormatter.Convert(negativeWholeHour));
+            Assert.Equal("2000-10-01-5", DateFormatter.ToParameterString(negativeWholeHour));
+
+            var positiveHalfHour = new DateTimeOffset(2000, 10, 1, 0, 0, 0, TimeSpan.FromHours(1.5));
+            Assert.Equal("2000-10-01 +1-30", DateFormatter.Convert(positiveHalfHour));
+            Assert.Equal("2000-10-01+1-30", DateFormatter.ToParameterString(positiveHalfHour));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
     static bool[] bools =
     [
         true,

--- a/src/Verify/Serialization/DateFormatter_DateTimeOffset.cs
+++ b/src/Verify/Serialization/DateFormatter_DateTimeOffset.cs
@@ -65,20 +65,20 @@ public static partial class DateFormatter
         {
             if (offset.Minutes == 0)
             {
-                return $"+{offset.TotalHours:0}";
+                return $"+{offset.TotalHours.ToString("0", Culture.InvariantCulture)}";
             }
 
-            return $"+{offset.Hours:0}-{offset.Minutes:00}";
+            return $"+{offset.Hours.ToString("0", Culture.InvariantCulture)}-{offset.Minutes.ToString("00", Culture.InvariantCulture)}";
         }
 
         if (offset < TimeSpan.Zero)
         {
             if (offset.Minutes == 0)
             {
-                return $"{offset.Hours:0}";
+                return offset.Hours.ToString("0", Culture.InvariantCulture);
             }
 
-            return $"{offset.Hours:0}{offset.Minutes:00}";
+            return $"{offset.Hours.ToString("0", Culture.InvariantCulture)}{offset.Minutes.ToString("00", Culture.InvariantCulture)}";
         }
 
         return "+0";

--- a/src/todo.md
+++ b/src/todo.md
@@ -29,7 +29,7 @@ All six resolved 2026-08-16 (five fixed here; the inline item resolved as by-des
 
 ## Correctness, narrower triggers
 
-- [ ] **Negative UTC offsets formatted with current culture.**
+- [x] **Negative UTC offsets formatted with current culture.**
   `Verify/Serialization/DateFormatter_DateTimeOffset.cs:78,81` — plain interpolation (`$"{offset.Hours:0}"`) uses `CurrentCulture` while every other call in the file passes `Culture.InvariantCulture`. Under `ar-SA` the negative sign renders as invisible U+061C + `-`, so a `DateTimeOffset` parameter with offset `-05:00` produces a filename that never matches a snapshot committed from an en-US machine. Also leaks into snapshot content via `Convert` when date scrubbing is off.
 
 - [ ] **Sub-millisecond date parameters collide.**


### PR DESCRIPTION
`DateFormatter.GetDateOffset` rendered the offset numbers with plain interpolation, so they used `CurrentCulture` while every other format call in `DateFormatter` passes `Culture.InvariantCulture`.

Under a culture whose negative sign is not `-` (for example `ar-SA`, which uses U+061C followed by `-`), a `DateTimeOffset` parameter with a negative offset produced a parameter string, and hence a file name, that never matched a snapshot committed from an en-US machine. The same value also leaked into snapshot content via `Convert` when date scrubbing is off.

All four format calls now go through `Culture.InvariantCulture`. Output is unchanged for cultures that already use the invariant signs.

Added `DateFormatterTests.OffsetIsNotAffectedByCurrentCulture`, which formats under a culture with a custom negative sign. It fails on `main` and passes with this change. Full `Verify.Tests` suite passes.
