### PR TITLE
Escape one character trimmed date formats

### DIFF
--- a/src/ApplyScrubbersTests/TrimmedFractionTests.cs
+++ b/src/ApplyScrubbersTests/TrimmedFractionTests.cs
@@ -1,0 +1,41 @@
+// Formats ending in an upper case fraction produce a second scrubber for the trimmed
+// format, since those fractions render as empty when zero. A one character format
+// string is a standard format specifier, so the trimmed format has to be escaped.
+public class TrimmedFractionTests
+{
+    static readonly CultureInfo enUs = new("en-US");
+
+    [Fact]
+    public void SingleCharTrimmedFormatDoesNotBecomeStandardFormat()
+    {
+        var scrubbers = DateMatchers.DateTimes("s.F", enUs);
+
+        // "s" as a standard format is the sortable pattern, so the trimmed scrubber
+        // used to swallow every full sortable date-time in the output
+        var result = EngineRunner.Run("2020-01-01T10:20:30", scrubbers);
+        Assert.NotEqual("DateTime_1", result);
+
+        // the seconds the format actually asks for still scrub
+        Assert.Equal("DateTime_1", EngineRunner.Run("9", scrubbers));
+    }
+
+    [Fact]
+    public void SingleCharTrimmedFormatIsNotRejected()
+    {
+        // "H" is not a standard format specifier, so trimming used to throw
+        // "Invalid format: H" at registration
+        var scrubbers = DateMatchers.DateTimes("H.F", enUs);
+
+        Assert.Equal(2, scrubbers.Length);
+        Assert.Equal("DateTime_1", EngineRunner.Run("9", scrubbers));
+    }
+
+    [Fact]
+    public void FractionOnlyFormatHasNoTrimmedScrubber()
+    {
+        // trimming leaves nothing to parse
+        var scrubbers = DateMatchers.DateTimes(".F", enUs);
+
+        Assert.Single(scrubbers);
+    }
+}

--- a/src/Verify/Serialization/Scrubbers/DateMatchers.cs
+++ b/src/Verify/Serialization/Scrubbers/DateMatchers.cs
@@ -268,31 +268,46 @@ static class DateMatchers
 
     static bool TryGetFormatWithUpperMillisecondsTrimmed(string format, [NotNullWhen(true)] out string? trimmedFormat)
     {
+        string trimmed;
         if (format.EndsWith(".FFFF", StringComparison.Ordinal))
         {
-            trimmedFormat = format[..^5];
-            return true;
+            trimmed = format[..^5];
         }
-
-        if (format.EndsWith(".FFF", StringComparison.Ordinal))
+        else if (format.EndsWith(".FFF", StringComparison.Ordinal))
         {
-            trimmedFormat = format[..^4];
-            return true;
+            trimmed = format[..^4];
         }
-
-        if (format.EndsWith(".FF", StringComparison.Ordinal))
+        else if (format.EndsWith(".FF", StringComparison.Ordinal))
         {
-            trimmedFormat = format[..^3];
-            return true;
+            trimmed = format[..^3];
         }
-
-        if (format.EndsWith(".F", StringComparison.Ordinal))
+        else if (format.EndsWith(".F", StringComparison.Ordinal))
         {
-            trimmedFormat = format[..^2];
+            trimmed = format[..^2];
+        }
+        else
+        {
+            trimmedFormat = null;
+            return false;
+        }
+
+        // Nothing is left to parse, so the untrimmed scrubber is the only one
+        if (trimmed.Length == 0)
+        {
+            trimmedFormat = null;
+            return false;
+        }
+
+        // A one character format string is read as a standard format specifier, so "s.F"
+        // would trim to the culture's sortable pattern and "H.F" to nothing valid at all.
+        // `%` forces the character to be read as the custom specifier it was written as.
+        if (trimmed.Length == 1)
+        {
+            trimmedFormat = $"%{trimmed}";
             return true;
         }
 
-        trimmedFormat = null;
-        return false;
+        trimmedFormat = trimmed;
+        return true;
     }
 }

--- a/src/todo.md
+++ b/src/todo.md
@@ -38,7 +38,7 @@ All six resolved 2026-08-16 (five fixed here; the inline item resolved as by-des
 - [ ] **`#` in parameter values collides with the indexed-target namespace.**
   `Verify/Naming/MatchingFileFinder.cs:9,20` — `indexedPattern: "{prefix}#"` matches by prefix, and `#` is not sanitized. Cases `"x"` and `"x#1"` on one method: running `"x"` deletes `C.M_p=x#1.received.txt` and sweeps `C.M_p=x#1.verified.txt` into the stale set (deleted under AutoVerify).
 
-- [ ] **Trimmed fraction format collapses into a standard format specifier.**
+- [x] **Trimmed fraction format collapses into a standard format specifier.**
   `Verify/Serialization/Scrubbers/DateMatchers.cs:269-297` (consumed at 118-127) — `ScrubInlineDateTimes("s.F")` builds a secondary scrubber for `"s"`; length-1 formats are standard specifiers, so it scrubs every full sortable date-time in the output. `"H.F"` trims to `"H"` and throws `Invalid format: H` at registration despite passing up-front validation.
 
 - [ ] **`MemberConverter` has no exact-type precedence.**


### PR DESCRIPTION
`DateMatchers.BuildForFormats` builds a second scrubber for the trimmed format when a format ends in an upper case fraction, since those render as empty when the fraction is zero. `TryGetFormatWithUpperMillisecondsTrimmed` handed back the trimmed string raw, and a one character format string is read as a *standard* format specifier rather than the custom one it was written as:

* `ScrubInlineDateTimes("s.F")` trimmed to `"s"`, which expands to the culture's sortable pattern — so the second scrubber scrubbed every full sortable date-time in the output.
* `ScrubInlineDateTimes("H.F")` trimmed to `"H"`, which is not a standard specifier at all — `Invalid format: H` at registration, after the format had already passed the up-front validation.

Now `%` escapes the trimmed format when one character is left, which is what forces it to be read as a custom specifier, and no second scrubber is built when trimming leaves nothing (`".F"`).

Tests in the new `TrimmedFractionTests` cover all three cases; all three fail on `main`. `ApplyScrubbersTests` (114), `Verify.Tests` (1299) and `StaticSettingsTests` pass.

Unrelated observation while in here: the trim only recognises `.F` through `.FFFF`, so `.FFFFF` through `.FFFFFFF` never get a trimmed scrubber. Left alone since `TryParseExact` treats the fraction (and its period) as optional anyway, which makes the second scrubber look redundant rather than missing — worth a separate look at whether it earns its keep at all.
