### PR TITLE
Report deletes as directory relative paths

### DIFF
--- a/docs/exception-message-format.md
+++ b/docs/exception-message-format.md
@@ -32,6 +32,8 @@ Then zero or more categorized sections, each listing file pairs:
  * **InlineNew** - an [inline snapshot](inline-snapshots.md) with no expected value yet.
  * **InlineNotEqual** - an inline snapshot whose expected value differs from the result.
 
+File paths in these sections are relative to the reported directory, and keep any subdirectory. `UseUniqueDirectory` and `VerifyDirectory` place snapshots in a subdirectory, so combining the reported directory with the listed path is what rebuilds the full path.
+
 Inline entries use a different shape: a `Source:` line with the absolute source file path and 1 based line number (`path:line`), followed by optional absolute staged file paths:
 
 ```
@@ -242,7 +244,7 @@ static Result ParseExceptionMessage(string exceptionMessage)
     return result;
 }
 ```
-<sup><a href='/src/Verify.ExceptionParsing.Tests/ExceptionParsingTests.cs#L291-L311' title='Snippet source file'>snippet source</a> | <a href='#snippet-ExceptionParsing' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.ExceptionParsing.Tests/ExceptionParsingTests.cs#L304-L324' title='Snippet source file'>snippet source</a> | <a href='#snippet-ExceptionParsing' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Result` contains:

--- a/docs/mdsource/exception-message-format.source.md
+++ b/docs/mdsource/exception-message-format.source.md
@@ -25,6 +25,8 @@ Then zero or more categorized sections, each listing file pairs:
  * **InlineNew** - an [inline snapshot](inline-snapshots.md) with no expected value yet.
  * **InlineNotEqual** - an inline snapshot whose expected value differs from the result.
 
+File paths in these sections are relative to the reported directory, and keep any subdirectory. `UseUniqueDirectory` and `VerifyDirectory` place snapshots in a subdirectory, so combining the reported directory with the listed path is what rebuilds the full path.
+
 Inline entries use a different shape: a `Source:` line with the absolute source file path and 1 based line number (`path:line`), followed by optional absolute staged file paths:
 
 ```

--- a/src/Verify.ExceptionParsing.Tests/ExceptionParsingTests.DeleteInSubDirectory.verified.txt
+++ b/src/Verify.ExceptionParsing.Tests/ExceptionParsingTests.DeleteInSubDirectory.verified.txt
@@ -1,0 +1,12 @@
+﻿{
+  message:
+Directory: {ProjectDirectory}
+Delete:
+  - TheType.TheMethod\old.verified.txt
+,
+  result: {
+    Delete: [
+      {ProjectDirectory}TheType.TheMethod\old.verified.txt
+    ]
+  }
+}

--- a/src/Verify.ExceptionParsing.Tests/ExceptionParsingTests.cs
+++ b/src/Verify.ExceptionParsing.Tests/ExceptionParsingTests.cs
@@ -199,6 +199,19 @@ public class ExceptionParsingTests
         return ParseVerify([], [], delete, []);
     }
 
+    // UseUniqueDirectory and VerifyDirectory put the verified files in a subdirectory
+    // of the reported directory, so the parse has to give the subdirectory back
+    [Fact]
+    public Task DeleteInSubDirectory()
+    {
+        var delete = new List<string>
+        {
+            Path.Combine(projectDirectory, "TheType.TheMethod", "old.verified.txt")
+        };
+
+        return ParseVerify([], [], delete, []);
+    }
+
     [Fact]
     public Task ParseInlineNew()
     {

--- a/src/Verify.ExceptionParsing.Tests/VerifyExceptionMessageBuilderTests.DeleteInSubDirectory.verified.txt
+++ b/src/Verify.ExceptionParsing.Tests/VerifyExceptionMessageBuilderTests.DeleteInSubDirectory.verified.txt
@@ -1,0 +1,3 @@
+﻿Directory: {ProjectDirectory}
+Delete:
+  - TheType.TheMethod\old.verified.txt

--- a/src/Verify.ExceptionParsing.Tests/VerifyExceptionMessageBuilderTests.cs
+++ b/src/Verify.ExceptionParsing.Tests/VerifyExceptionMessageBuilderTests.cs
@@ -88,6 +88,16 @@ public class VerifyExceptionMessageBuilderTests
             delete: [fakeReceivedTextFile],
             equal: []);
 
+    // UseUniqueDirectory and VerifyDirectory put the verified files in a subdirectory
+    // of the reported directory, which a file name would drop
+    [Fact]
+    public Task DeleteInSubDirectory() =>
+        BuildVerify(
+            @new: [],
+            notEquals: [],
+            delete: [Path.Combine(projectDirectory, "TheType.TheMethod", "old.verified.txt")],
+            equal: []);
+
     [Fact]
     public Task SingleEqual() =>
         BuildVerify(

--- a/src/Verify/Verifier/VerifyExceptionMessageBuilder.cs
+++ b/src/Verify/Verifier/VerifyExceptionMessageBuilder.cs
@@ -59,7 +59,10 @@ static class VerifyExceptionMessageBuilder
             builder.AppendLineN("Delete:");
             foreach (var file in delete)
             {
-                builder.AppendLineN($"  - {Path.GetFileName(file)}");
+                // directory relative, like the other sections, so the parser can
+                // rebuild the path. UseUniqueDirectory and VerifyDirectory put the
+                // verified files in a subdirectory, which a file name would drop.
+                builder.AppendLineN($"  - {IoHelpers.GetRelativePath(directory, file)}");
             }
         }
 

--- a/src/todo.md
+++ b/src/todo.md
@@ -53,7 +53,7 @@ All six resolved 2026-08-16 (five fixed here; the inline item resolved as by-des
 - [ ] **MSTest overloaded test methods resolve to the wrong `MethodInfo`.**
   `Verify.MSTest/TestExecutionContext.cs:24-30` — `FindMethod` returns the first name match, ignoring parameters. With two `[DataRow]` overloads of one name, the parameter-count guard in `Verifier.BuildVerifier` mismatches for one of them → `SetParameters` silently skipped → both overloads collide on one snapshot prefix.
 
-- [ ] **`Delete:` section drops subdirectories, breaking the parse round-trip.**
+- [x] **`Delete:` section drops subdirectories, breaking the parse round-trip.**
   `Verify/Verifier/VerifyExceptionMessageBuilder.cs:62` emits `Path.GetFileName(file)` while the other sections emit directory-relative paths, and `Verify.ExceptionParsing/Parser.cs:109` reconstructs with `Path.Combine(directory, name)`. For `UseUniqueDirectory()`/`VerifyDirectory` tests, a stale `{Directory}\Type.Method\old.verified.txt` parses back as the nonexistent `{Directory}\old.verified.txt`; same-named files in different subdirectories collapse.
 
 - [ ] **`ThrowIfVerifyHasBeenRun` blames the caller instead of the API.**


### PR DESCRIPTION
The `Delete:` section emitted `Path.GetFileName(file)`, while `New:`, `NotEqual:` and `Equal:` all emit a path relative to the reported directory, and `Verify.ExceptionParsing` rebuilds each delete entry with `Path.Combine(directory, name)`.

For flat layouts the two agree, so this only shows up where snapshots live in a subdirectory — `UseUniqueDirectory()` and `VerifyDirectory`. A stale `{Directory}\Type.Method\old.verified.txt` was reported as just `old.verified.txt` and parsed back as `{Directory}\old.verified.txt`, which does not exist. Same-named files in different subdirectories also collapsed onto one entry.

The section now uses `IoHelpers.GetRelativePath`, the same call the other sections use, so the round trip holds.

Also documents the invariant in `exception-message-format.md`: the file listing paths are relative to the reported directory and keep any subdirectory. The doc previously only said the *inline* paths are absolute, leaving the file sections implicit.

Two tests, one per side of the round trip: `VerifyExceptionMessageBuilderTests.DeleteInSubDirectory` for what is emitted, and `ExceptionParsingTests.DeleteInSubDirectory` for what comes back. On `main` both produce `old.verified.txt` / `{ProjectDirectory}old.verified.txt`.

`Verify.ExceptionParsing.Tests` (84 across net11.0 and net48), `Verify.Tests` (1299) and `StaticSettingsTests` pass. No existing snapshot changed — the other `Delete:` snapshots all use flat paths.
