### PR TITLE
Keep stack frames that have no parameter list

### DIFF
--- a/src/Verify.Tests/ScrubStackTrace.cs
+++ b/src/Verify.Tests/ScrubStackTrace.cs
@@ -31,6 +31,34 @@
         return Verify(scrubbed);
     }
 
+    // NativeAOT renders unresolved frames with no parameter list
+    [Fact]
+    public Task NoParens()
+    {
+        var scrubbed = ScrubStackTrace.Scrub(
+            """
+            System.Exception: Boom
+               at MyApp!<BaseAddress>+0x1a2b3c
+               at MyApp.Program.Main(String[] args) in /src/Program.cs:line 12
+               at MyApp!<BaseAddress>+0x4d5e6f
+            """);
+        return Verify(scrubbed);
+    }
+
+    [Fact]
+    public Task NoParens_RemoveParams()
+    {
+        var scrubbed = ScrubStackTrace.Scrub(
+            """
+            System.Exception: Boom
+               at MyApp!<BaseAddress>+0x1a2b3c
+               at MyApp.Program.Main(String[] args) in /src/Program.cs:line 12
+               at MyApp!<BaseAddress>+0x4d5e6f
+            """,
+            removeParams: true);
+        return Verify(scrubbed);
+    }
+
     [Fact]
     public Task WhiteSpace()
     {

--- a/src/Verify.Tests/ScrubStackTraceTests.NoParens.verified.txt
+++ b/src/Verify.Tests/ScrubStackTraceTests.NoParens.verified.txt
@@ -1,0 +1,4 @@
+﻿System.Exception: Boom
+at MyApp!<BaseAddress>+0x1a2b3c
+at MyApp.Program.Main(String[] args)
+at MyApp!<BaseAddress>+0x4d5e6f

--- a/src/Verify.Tests/ScrubStackTraceTests.NoParens_RemoveParams.verified.txt
+++ b/src/Verify.Tests/ScrubStackTraceTests.NoParens_RemoveParams.verified.txt
@@ -1,0 +1,4 @@
+﻿System.Exception: Boom
+at MyApp!<BaseAddress>+0x1a2b3c
+at MyApp.Program.Main(...)
+at MyApp!<BaseAddress>+0x4d5e6f

--- a/src/Verify/Serialization/Scrubbers/ScrubStackTrace.cs
+++ b/src/Verify/Serialization/Scrubbers/ScrubStackTrace.cs
@@ -36,6 +36,16 @@
             var indexOfLeft = span.IndexOf('(');
 
             var indexOfRight = span.IndexOf(')');
+
+            // Not every frame has a parameter list. NativeAOT renders unresolved frames
+            // as `at MyApp!<BaseAddress>+0x1a2b3c`, which has nothing to trim.
+            if (indexOfLeft == -1 ||
+                indexOfRight == -1)
+            {
+                builder.AppendLineN(span);
+                continue;
+            }
+
             if (removeParams)
             {
                 var next = indexOfLeft + 1;

--- a/src/todo.md
+++ b/src/todo.md
@@ -61,7 +61,7 @@ All six resolved 2026-08-16 (five fixed here; the inline item resolved as by-des
 
 ## Minor / edge cases
 
-- [ ] **Stack-trace scrubber destroys paren-less `at` frames** (NativeAOT: `at MyApp!<BaseAddress>+0x1a2b3c`).
+- [x] **Stack-trace scrubber destroys paren-less `at` frames** (NativeAOT: `at MyApp!<BaseAddress>+0x1a2b3c`).
   `Verify/Serialization/Scrubbers/ScrubStackTrace.cs:36-58` — `IndexOf('(')`/`')'` return −1, slice keeps zero chars → frame becomes an empty line, or the literal `...)` with `removeParams: true`.
 
 - [ ] **MSTest source generator ignores `record` test classes.**


### PR DESCRIPTION
`ScrubStackTrace` trims each `at` frame at its closing paren, but not every frame has one. NativeAOT renders unresolved frames as:

```
at MyApp!<BaseAddress>+0x1a2b3c
```

Both `IndexOf` calls return -1, so `span[..(indexOfRight + 1)]` keeps zero characters and the frame becomes an empty line — or the literal `...)` under `removeParams`. Captured on `main`:

```
System.Exception: Boom
                                 <- the frame
at MyApp.Program.Main(String[] args)
                                 <- and this one vanished entirely, trailing newline trimmed
```

Frames with no parameter list are now emitted as they are. That also leaves the `+` in the offset alone — routing them through `WriteReplacePlus` would have rewritten `+0x1a2b3c` to `.0x1a2b3c`, since that helper exists to turn the nested type separator into a dot.

`NoParens` and `NoParens_RemoveParams` cover both paths, each mixing unresolved frames with a normal one. `Verify.Tests` (1301) passes.
