### PR TITLE
Sign sub-hour UTC offsets

### DIFF
--- a/docs/type-to-string-mapping.md
+++ b/docs/type-to-string-mapping.md
@@ -268,39 +268,32 @@ public static partial class DateFormatter
     }
 
     // Interpolation formats with the current culture, and NumberFormatInfo.NegativeSign is not "-"
-    // everywhere: sv-SE renders U+2212 and ar-SA prefixes U+061C. A negative offset carries that
-    // sign into both snapshot content and parameter file names, so the culture is pinned here the
-    // same way it is for every date part above
+    // everywhere: sv-SE renders U+2212 and ar-SA prefixes U+061C. The offset reaches both snapshot
+    // content and parameter file names, so the culture is pinned here the same way it is for every
+    // date part above, and the sign is written as a literal rather than taken from a negative number.
     static string GetDateOffset(DateTimeOffset value)
     {
         var offset = value.Offset;
 
-        if (offset > TimeSpan.Zero)
+        if (offset == TimeSpan.Zero)
         {
-            if (offset.Minutes == 0)
-            {
-                return FormattableString.Invariant($"+{offset.TotalHours:0}");
-            }
-
-            return FormattableString.Invariant($"+{offset.Hours:0}-{offset.Minutes:00}");
+            return "+0";
         }
 
-        if (offset < TimeSpan.Zero)
-        {
-            if (offset.Minutes == 0)
-            {
-                return FormattableString.Invariant($"{offset.Hours:0}");
-            }
+        // The sign belongs to the offset as a whole. Taking it from the hour component
+        // instead loses it for a sub hour offset, where that component is zero.
+        var sign = offset < TimeSpan.Zero ? '-' : '+';
 
-            // Minutes is negative too, which is what renders the separator
-            return FormattableString.Invariant($"{offset.Hours:0}{offset.Minutes:00}");
+        if (offset.Minutes == 0)
+        {
+            return FormattableString.Invariant($"{sign}{Math.Abs(offset.TotalHours):0}");
         }
 
-        return "+0";
+        return FormattableString.Invariant($"{sign}{Math.Abs(offset.Hours):0}-{Math.Abs(offset.Minutes):00}");
     }
 }
 ```
-<sup><a href='/src/Verify/Serialization/DateFormatter_DateTimeOffset.cs#L1-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-DateFormatter_DateTimeOffset.cs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify/Serialization/DateFormatter_DateTimeOffset.cs#L1-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-DateFormatter_DateTimeOffset.cs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Verify.Tests/DateFormatterTests.cs
+++ b/src/Verify.Tests/DateFormatterTests.cs
@@ -227,6 +227,24 @@
         });
     }
 
+    // A sub hour offset has a zero hour component, so the sign has to come from
+    // the offset itself
+    [Fact]
+    public void SubHourOffsets()
+    {
+        var negative = new DateTimeOffset(2000, 10, 1, 0, 0, 0, TimeSpan.FromMinutes(-30));
+        Assert.Equal("2000-10-01 -0-30", DateFormatter.Convert(negative));
+        Assert.Equal("2000-10-01-0-30", DateFormatter.ToParameterString(negative));
+
+        var positive = new DateTimeOffset(2000, 10, 1, 0, 0, 0, TimeSpan.FromMinutes(30));
+        Assert.Equal("2000-10-01 +0-30", DateFormatter.Convert(positive));
+        Assert.Equal("2000-10-01+0-30", DateFormatter.ToParameterString(positive));
+
+        Assert.NotEqual(
+            DateFormatter.ToParameterString(negative),
+            DateFormatter.ToParameterString(positive));
+    }
+
     static bool[] bools =
     [
         true,

--- a/src/Verify/Serialization/DateFormatter_DateTimeOffset.cs
+++ b/src/Verify/Serialization/DateFormatter_DateTimeOffset.cs
@@ -58,34 +58,27 @@ public static partial class DateFormatter
     }
 
     // Interpolation formats with the current culture, and NumberFormatInfo.NegativeSign is not "-"
-    // everywhere: sv-SE renders U+2212 and ar-SA prefixes U+061C. A negative offset carries that
-    // sign into both snapshot content and parameter file names, so the culture is pinned here the
-    // same way it is for every date part above
+    // everywhere: sv-SE renders U+2212 and ar-SA prefixes U+061C. The offset reaches both snapshot
+    // content and parameter file names, so the culture is pinned here the same way it is for every
+    // date part above, and the sign is written as a literal rather than taken from a negative number.
     static string GetDateOffset(DateTimeOffset value)
     {
         var offset = value.Offset;
 
-        if (offset > TimeSpan.Zero)
+        if (offset == TimeSpan.Zero)
         {
-            if (offset.Minutes == 0)
-            {
-                return FormattableString.Invariant($"+{offset.TotalHours:0}");
-            }
-
-            return FormattableString.Invariant($"+{offset.Hours:0}-{offset.Minutes:00}");
+            return "+0";
         }
 
-        if (offset < TimeSpan.Zero)
-        {
-            if (offset.Minutes == 0)
-            {
-                return FormattableString.Invariant($"{offset.Hours:0}");
-            }
+        // The sign belongs to the offset as a whole. Taking it from the hour component
+        // instead loses it for a sub hour offset, where that component is zero.
+        var sign = offset < TimeSpan.Zero ? '-' : '+';
 
-            // Minutes is negative too, which is what renders the separator
-            return FormattableString.Invariant($"{offset.Hours:0}{offset.Minutes:00}");
+        if (offset.Minutes == 0)
+        {
+            return FormattableString.Invariant($"{sign}{Math.Abs(offset.TotalHours):0}");
         }
 
-        return "+0";
+        return FormattableString.Invariant($"{sign}{Math.Abs(offset.Hours):0}-{Math.Abs(offset.Minutes):00}");
     }
 }

--- a/src/todo.md
+++ b/src/todo.md
@@ -73,7 +73,7 @@ All six resolved 2026-08-16 (five fixed here; the inline item resolved as by-des
 - [ ] **`FlattenMessage` omits the joining space after a line ending in `.`.**
   `Verify/Combinations/CombinationResultsConverter.cs:168-183` — two-line messages (net48 `ArgumentNullException`) render as `"Value cannot be null.Parameter name: p"`.
 
-- [ ] **Negative sub-hour offsets render unsigned.**
+- [x] **Negative sub-hour offsets render unsigned.**
   `Verify/Serialization/DateFormatter_DateTimeOffset.cs:74-82` — `TimeSpan.FromMinutes(-30)` renders `0-30` (positive twin is `+0-30`). No real timezone in that range; constructed offsets only.
 
 - [ ] **Mismatch crash for handle-based `FileStream` received streams.**


### PR DESCRIPTION
`GetDateOffset` took the sign from the hour component. For an offset of less than an hour that component is zero, so `TimeSpan.FromMinutes(-30)` rendered as `0-30` while its positive twin rendered `+0-30` — the two are indistinguishable by sign, and a negative offset silently reads as positive.

The sign now comes from the offset as a whole and the components are rendered unsigned. Every other case renders exactly as before: `-1-30`, `-5`, `+1-30`, `+5`, `+0`.

Only reachable with a constructed offset, since no real timezone sits in that range.

**Based on #1854**, not `main` — both rewrite the same four returns in `GetDateOffset`, so this is stacked to avoid a conflict. It keeps that PR's `FormattableString.Invariant` style and its theory test untouched; the culture pinning still matters for the digits, and the sign is now a literal rather than a formatted negative number, which the comment there has been updated to say.

`DateFormatterTests.SubHourOffsets` covers both signs and asserts the two no longer render the same. Full `Verify.Tests` passes on the rebased branch: 1305.