### PR TITLE
Write the received file from the stream for handle based FileStreams

### DIFF
--- a/src/Verify.Tests/Comparer/HandleStreamTests.Mismatch.verified.bin
+++ b/src/Verify.Tests/Comparer/HandleStreamTests.Mismatch.verified.bin
@@ -1,0 +1,1 @@
+TheVerifiedValue

--- a/src/Verify.Tests/Comparer/HandleStreamTests.cs
+++ b/src/Verify.Tests/Comparer/HandleStreamTests.cs
@@ -1,0 +1,24 @@
+// A FileStream built from a handle may have no usable Name: .NET Framework reports
+// "[Unknown]", and modern .NET falls back to that when the path cannot be resolved
+// from the handle. The New path already copes, so only a mismatch exercised it.
+public class HandleStreamTests
+{
+    [Fact]
+    public async Task Mismatch()
+    {
+        using var directory = new TempDirectory();
+        var path = directory.BuildPath("source.txt");
+        File.WriteAllText(path, "TheReceivedValue");
+
+        using var source = File.OpenRead(path);
+        using var stream = new FileStream(source.SafeFileHandle, FileAccess.Read);
+
+        var settings = new VerifySettings();
+        settings.DisableDiff();
+
+        await Assert.ThrowsAsync<VerifyException>(() => Verify(stream, "bin", settings));
+
+        var received = CurrentFile.Relative($"HandleStreamTests.Mismatch.{Namer.RuntimeAndVersion}.received.bin");
+        Assert.Equal("TheReceivedValue", File.ReadAllText(received));
+    }
+}

--- a/src/Verify/Compare/FileComparer.cs
+++ b/src/Verify/Compare/FileComparer.cs
@@ -47,7 +47,10 @@
                 return new(Equality.Equal, compareResult.Message, null, null);
             }
 
-            IoHelpers.CopyFile(fileStream.Name, file.ReceivedPath);
+            // Not CopyFile(fileStream.Name): a FileStream built from a handle has no
+            // usable Name. WriteStream keeps the copy-by-path fast path and falls back
+            // to the handle, which is what the New and empty paths above already do.
+            await IoHelpers.WriteStream(file.ReceivedPath, fileStream);
             return new(Equality.NotEqual, compareResult.Message, null, null);
         }
 

--- a/src/todo.md
+++ b/src/todo.md
@@ -76,7 +76,7 @@ All six resolved 2026-08-16 (five fixed here; the inline item resolved as by-des
 - [ ] **Negative sub-hour offsets render unsigned.**
   `Verify/Serialization/DateFormatter_DateTimeOffset.cs:74-82` — `TimeSpan.FromMinutes(-30)` renders `0-30` (positive twin is `+0-30`). No real timezone in that range; constructed offsets only.
 
-- [ ] **Mismatch crash for handle-based `FileStream` received streams.**
+- [x] **Mismatch crash for handle-based `FileStream` received streams.**
   `Verify/Compare/FileComparer.cs:50` — NotEqual fast path copies by `fileStream.Name` with no fallback; handle-based streams have `Name == "[Unknown]"`. First (New) run succeeds via the guarded `IoHelpers.WriteStream` path; later mismatches throw the generic "Failed to compare files".
 
 - [ ] **`PrefixUnique` set is case-sensitive on case-insensitive filesystems.**


### PR DESCRIPTION
`FileComparer.InnerCompare` writes the received file on a mismatch with `IoHelpers.CopyFile(fileStream.Name, …)`. `Name` is not a path for a `FileStream` built from a handle — .NET Framework reports `[Unknown]`, and modern .NET falls back to that when the path cannot be resolved from the handle.

The first run of such a test passes: the New path goes through `IoHelpers.WriteStream`, which already guards for this (`TryFileCopy` bails on a non rooted name and copies through the handle instead). The next run, once a `.verified.` file exists and the content differs, throws:

```
System.Exception : Failed to compare files:
---- System.IO.FileNotFoundException : Could not find file '[Unknown]'.
```

So `WriteStream` replaces the raw copy here — same copy-by-path fast path, with the fallback the other paths already get.

`HandleStreamTests.Mismatch` opens a `FileStream` over another stream's `SafeFileHandle` and verifies it against a differing snapshot. Two notes on how it is built:

* It uses a **binary** extension. With a text extension the stream is read into a `StringBuilder` up front and `FileComparer` is never reached, so the test would pass without proving anything.
* The two contents are the **same length**, so the length fast path (which calls `WriteStream` and is therefore already safe) does not short-circuit ahead of the comparison.

On net48 it reproduces the crash above; on net11.0 the handle resolves back to a real path, so it passes either way there and only asserts the outcome. Full `Verify.Tests` passes on both net48 (1221) and net11.0 (1300).
