### PR TITLE
Compare prefixes ignoring case

### DIFF
--- a/src/Verify.Tests/Naming/PrefixUniqueTests.cs
+++ b/src/Verify.Tests/Naming/PrefixUniqueTests.cs
@@ -1,0 +1,22 @@
+public class PrefixUniqueTests
+{
+    // The prefix maps to file names, and two prefixes differing only in case share
+    // one set of files on NTFS and APFS
+    [Fact]
+    public void CaseOnlyDifferenceIsNotUnique()
+    {
+        PrefixUnique.CheckPrefixIsUnique("PrefixUniqueTests.TheCase");
+
+        var exception = Assert.Throws<Exception>(
+            () => PrefixUnique.CheckPrefixIsUnique("prefixuniquetests.thecase"));
+
+        Assert.Contains("The prefix has already been used", exception.Message);
+    }
+
+    [Fact]
+    public void DistinctPrefixesAreUnique()
+    {
+        PrefixUnique.CheckPrefixIsUnique("PrefixUniqueTests.Distinct1");
+        PrefixUnique.CheckPrefixIsUnique("PrefixUniqueTests.Distinct2");
+    }
+}

--- a/src/Verify/Naming/PrefixUnique.cs
+++ b/src/Verify/Naming/PrefixUnique.cs
@@ -1,6 +1,9 @@
 ﻿static class PrefixUnique
 {
-    static ConcurrentDictionary<string, byte> prefixSet = [];
+    // Ignoring case, since the prefix maps to file names and NTFS and APFS are both
+    // case insensitive. Two prefixes differing only in case would silently share one
+    // set of files there, and a snapshot repository has to work on every platform.
+    static ConcurrentDictionary<string, byte> prefixSet = new(StringComparer.OrdinalIgnoreCase);
 
     public static void CheckPrefixIsUnique(string prefix)
     {

--- a/src/todo.md
+++ b/src/todo.md
@@ -79,7 +79,7 @@ All six resolved 2026-08-16 (five fixed here; the inline item resolved as by-des
 - [ ] **Mismatch crash for handle-based `FileStream` received streams.**
   `Verify/Compare/FileComparer.cs:50` — NotEqual fast path copies by `fileStream.Name` with no fallback; handle-based streams have `Name == "[Unknown]"`. First (New) run succeeds via the guarded `IoHelpers.WriteStream` path; later mismatches throw the generic "Failed to compare files".
 
-- [ ] **`PrefixUnique` set is case-sensitive on case-insensitive filesystems.**
+- [x] **`PrefixUnique` set is case-sensitive on case-insensitive filesystems.**
   `Verify/Naming/PrefixUnique.cs:3` — methods `Foo` and `foo` map to the same files on NTFS/APFS but pass the uniqueness check and silently clobber each other.
 
 - [ ] **`Counter` caches mix `Interlocked` counters with unsynchronized `Dictionary` writes.**


### PR DESCRIPTION
`PrefixUnique` kept its set with the default (case sensitive) comparer, but the prefix maps to file names, and NTFS and APFS are both case insensitive. Two test methods `Foo` and `foo` therefore passed the uniqueness check and then silently shared one set of snapshot files, each overwriting the other's.

The check now ignores case with `StringComparer.OrdinalIgnoreCase`.

**A deliberate call**: this applies on every platform, not only where the filesystem is case insensitive. On Linux the two prefixes really are distinct files, so this rejects something that would technically work there. That seems right for a snapshot repository — the files are committed and shared, so a pair that only differs in case is broken for everyone on Windows or macOS, and the failure should surface wherever it is authored rather than only in someone else's checkout. It is also consistent with `VerifyEngine`, which already builds its delete set with an ignore-case comparer. `DisableRequireUniquePrefix()` remains the escape hatch.

`PrefixUniqueTests` covers both directions. `Verify.Tests` (1301), `StaticSettingsTests` and `Verify.NUnit.Tests` pass.
