### PR TITLE
Guard the counter value caches with a lock

### DIFF
--- a/src/Verify.Tests/CounterConcurrencyTests.cs
+++ b/src/Verify.Tests/CounterConcurrencyTests.cs
@@ -1,0 +1,50 @@
+// User code can reach Counter.Current from parallel work inside one test, so the
+// value caches have to survive concurrent access
+public class CounterConcurrencyTests
+{
+    [Fact]
+    public void ConcurrentGuids()
+    {
+        using var counter = Counter.Start();
+
+        var guids = Enumerable.Range(0, 500)
+            .Select(_ => Guid.NewGuid())
+            .ToList();
+
+        var names = new ConcurrentBag<string>();
+        Parallel.ForEach(guids, guid => names.Add(counter.NextString(guid)));
+
+        // one name per distinct input, and no name handed out twice
+        Assert.Equal(guids.Count, names.Distinct().Count());
+
+        // and the same input keeps the name it was given
+        foreach (var guid in guids)
+        {
+            Assert.Contains(counter.NextString(guid), names);
+        }
+
+        Assert.Equal(guids.Count, names.Distinct().Count());
+    }
+
+    [Fact]
+    public void ConcurrentNumericIds()
+    {
+        using var counter = Counter.Start();
+
+        var ids = Enumerable.Range(0, 500)
+            .Select(_ => (long) _)
+            .ToList();
+
+        var names = new ConcurrentBag<string>();
+        Parallel.ForEach(ids, id => names.Add(counter.NextNumericIdString("TheEntity", id)));
+
+        Assert.Equal(ids.Count, names.Distinct().Count());
+
+        foreach (var id in ids)
+        {
+            Assert.Contains(counter.NextNumericIdString("TheEntity", id), names);
+        }
+
+        Assert.Equal(ids.Count, names.Distinct().Count());
+    }
+}

--- a/src/Verify/Counter.cs
+++ b/src/Verify/Counter.cs
@@ -10,6 +10,10 @@ public partial class Counter :
     Dictionary<DateTime, string> namedDateTimes;
     Dictionary<Guid, string> namedGuids;
     Dictionary<DateTimeOffset, string> namedDateTimeOffsets;
+    // Guards every value cache below. User code can reach Counter.Current from
+    // parallel work inside one test, and a Dictionary does not survive that.
+    internal object cacheLock = new();
+
     public bool DateCounting { get; }
     public bool ScrubDateTimes { get; }
     public bool ScrubGuids { get; }

--- a/src/Verify/Counter_Date.cs
+++ b/src/Verify/Counter_Date.cs
@@ -29,14 +29,18 @@ public partial class Counter
             return new(0, name);
         }
 
-        return dateCache.GetOrAdd(
-            input,
-            _ => BuildDateValue());
+        lock (cacheLock)
+        {
+            return dateCache.GetOrAdd(
+                input,
+                _ => BuildDateValue());
+        }
     }
 
+    // Called under cacheLock
     (int intValue, string stringValue) BuildDateValue()
     {
-        var value = Interlocked.Increment(ref currentDate);
+        var value = ++currentDate;
 
         if (DateCounting)
         {
@@ -54,9 +58,10 @@ public partial class Counter
     Dictionary<DateTime, (int intValue, string stringValue)> dateCache = new(dateTimeComparer);
     int currentDate;
 
+    // Called under cacheLock
     (int intValue, string stringValue) BuildDateValue()
     {
-        var value = Interlocked.Increment(ref currentDate);
+        var value = ++currentDate;
 
         if (DateCounting)
         {
@@ -78,10 +83,13 @@ public partial class Counter
             return "Date_MinValue";
         }
 
-        return dateCache.GetOrAdd(
-            date,
-            _ => BuildDateValue())
-            .stringValue;
+        lock (cacheLock)
+        {
+            return dateCache.GetOrAdd(
+                    date,
+                    _ => BuildDateValue())
+                .stringValue;
+        }
     }
 }
 #endif

--- a/src/Verify/Counter_DateTime.cs
+++ b/src/Verify/Counter_DateTime.cs
@@ -48,14 +48,18 @@ public partial class Counter
             return new(0, name);
         }
 
-        return dateTimeCache.GetOrAdd(
-            input,
-            _ => BuildDateTimeValue());
+        lock (cacheLock)
+        {
+            return dateTimeCache.GetOrAdd(
+                input,
+                _ => BuildDateTimeValue());
+        }
     }
 
+    // Called under cacheLock
     (int intValue, string stringValue) BuildDateTimeValue()
     {
-        var value = Interlocked.Increment(ref currentDateTime);
+        var value = ++currentDateTime;
 
         if (DateCounting)
         {

--- a/src/Verify/Counter_DateTimeOffset.cs
+++ b/src/Verify/Counter_DateTimeOffset.cs
@@ -48,14 +48,18 @@ public partial class Counter
             return new(0, name);
         }
 
-        return dateTimeOffsetCache.GetOrAdd(
-            input,
-            _ => BuildDateTimeOffsetValue());
+        lock (cacheLock)
+        {
+            return dateTimeOffsetCache.GetOrAdd(
+                input,
+                _ => BuildDateTimeOffsetValue());
+        }
     }
 
+    // Called under cacheLock
     (int intValue, string stringValue) BuildDateTimeOffsetValue()
     {
-        var value = Interlocked.Increment(ref currentDateTimeOffset);
+        var value = ++currentDateTimeOffset;
 
         if (DateCounting)
         {

--- a/src/Verify/Counter_Guid.cs
+++ b/src/Verify/Counter_Guid.cs
@@ -28,14 +28,18 @@ public partial class Counter
             return new(0, name);
         }
 
-        return guidCache.GetOrAdd(
-            input,
-            _ => BuildGuidValue());
+        lock (cacheLock)
+        {
+            return guidCache.GetOrAdd(
+                input,
+                _ => BuildGuidValue());
+        }
     }
 
+    // Called under cacheLock
     (int intValue, string stringValue) BuildGuidValue()
     {
-        var value = Interlocked.Increment(ref currentGuid);
+        var value = ++currentGuid;
         return (value, $"Guid_{value}");
     }
 }

--- a/src/Verify/Counter_NumericId.cs
+++ b/src/Verify/Counter_NumericId.cs
@@ -33,17 +33,21 @@ public partial class Counter
 
     (int intValue, string stringValue) NextNumericIdValue(string entityName, string input)
     {
-        if (!numericIdCache.TryGetValue(entityName, out var cache))
+        lock (cacheLock)
         {
-            cache = [];
-            numericIdCache[entityName] = cache;
-        }
+            if (!numericIdCache.TryGetValue(entityName, out var cache))
+            {
+                cache = [];
+                numericIdCache[entityName] = cache;
+            }
 
-        return cache.GetOrAdd(
-            input,
-            _ => BuildNumericIdValue(entityName));
+            return cache.GetOrAdd(
+                input,
+                _ => BuildNumericIdValue(entityName));
+        }
     }
 
+    // Called under cacheLock
     (int intValue, string stringValue) BuildNumericIdValue(string entityName)
     {
         numericIdCounters.TryGetValue(entityName, out var current);

--- a/src/Verify/Counter_Time.cs
+++ b/src/Verify/Counter_Time.cs
@@ -43,14 +43,18 @@ public partial class Counter
             return new(0, name);
         }
 
-        return timeCache.GetOrAdd(
-            input,
-            _ => BuildTimeValue());
+        lock (cacheLock)
+        {
+            return timeCache.GetOrAdd(
+                input,
+                _ => BuildTimeValue());
+        }
     }
 
+    // Called under cacheLock
     (int intValue, string stringValue) BuildTimeValue()
     {
-        var value = Interlocked.Increment(ref currentTime);
+        var value = ++currentTime;
         return (value, $"Time_{value}");
     }
 }

--- a/src/todo.md
+++ b/src/todo.md
@@ -82,5 +82,5 @@ All six resolved 2026-08-16 (five fixed here; the inline item resolved as by-des
 - [ ] **`PrefixUnique` set is case-sensitive on case-insensitive filesystems.**
   `Verify/Naming/PrefixUnique.cs:3` — methods `Foo` and `foo` map to the same files on NTFS/APFS but pass the uniqueness check and silently clobber each other.
 
-- [ ] **`Counter` caches mix `Interlocked` counters with unsynchronized `Dictionary` writes.**
+- [x] **`Counter` caches mix `Interlocked` counters with unsynchronized `Dictionary` writes.**
   `Verify/Counter_*.cs` → `Extensions.cs:155-164` — concurrent `Counter.Current.Next(...)` calls from parallel user code inside one test can corrupt the plain `Dictionary`.


### PR DESCRIPTION
Each `Counter` value cache (`Guid`, `DateTime`, `DateTimeOffset`, `Date`, `Time`, numeric id) is a plain `Dictionary` written through `Extensions.GetOrAdd`, while the number behind the name came from `Interlocked.Increment`. The mix reads as thread safe but is not: the interlocked part guards only the counter, not the dictionary that stores the result.

`Counter.Current` is public and reachable from user code, so parallel work inside a single test hits it concurrently. On `main` that reliably produces:

```
System.InvalidOperationException : Operations that change non-concurrent collections
must have exclusive access. A concurrent update was performed on this collection and
corrupted its state.
```

and sometimes `Destination array was not long enough` from a resize racing a read.

All the caches now share one lock. `ConcurrentDictionary` would have been the smaller diff, but its `GetOrAdd` can run the factory more than once under contention, which would burn counter numbers and hand out a name that is then discarded. A lock keeps the numbering tight, and it also covers the numeric id path, which mutates two dictionaries (the per entity cache and the per entity counter) that no single concurrent collection would make atomic together.

With the caches locked the interlocked increments are redundant, so they become plain increments, and the `Build*` methods are commented as being called under the lock.

`CounterConcurrencyTests` drives 500 distinct values through `Parallel.ForEach` for guids and numeric ids, asserting one name per input and that each input keeps its name. Both fail on `main` — 3 runs out of 3 while checking.

`Verify.Tests` passes on net11.0 (1301) and net48 (1222); `StaticSettingsTests` and `ApplyScrubbersTests` pass.
