### PR TITLE
Upgrade Argon to 0.36.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CA1822;CS1591;CS0649;xUnit1026;xUnit1013;CS1573;VerifyTestsProjectDir;VerifySetParameters;PolyFillTargetsForNuget;xUnit1051;NU1608;NU1109</NoWarn>
-    <Version>33.0.0-beta.1</Version>
+    <Version>33.0.0-beta.2</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Argon" Version="0.35.2" />
-    <PackageVersion Include="Argon.FSharp" Version="0.35.2" />
+    <PackageVersion Include="Argon" Version="0.36.0" />
+    <PackageVersion Include="Argon.FSharp" Version="0.36.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="DiffEngine" Version="20.1.2" />
     <PackageVersion Include="Expecto" Version="11.1.0" />


### PR DESCRIPTION
Update Argon and Argon.FSharp package versions from 0.35.2 to 0.36.0.