### PR TITLE
Cache whether a type is a collection

### DIFF
--- a/src/Verify.Tests/ReflectionHelpersTests.cs
+++ b/src/Verify.Tests/ReflectionHelpersTests.cs
@@ -35,7 +35,18 @@ public class ReflectionHelpersTests
             { new ImmutableArray<int>(), true },
             { uninitializedImmutableArray, true },
             { ImmutableDictionary.Create<byte, string>(), true },
-            { new Dictionary<string, object>(), true}
+            { new Dictionary<string, object>(), true},
+            // Below here nothing is a non generic ICollection, so each is classified by
+            // the per type lookup rather than the fast path
+            { new HashSet<int>(), true },
+            { new HashSet<int> { 1 }, false },
+            { Enumerable.Empty<int>(), true },
+            { Array.Empty<int>().ToLookup(_ => _), true },
+            { new[] { 1 }.ToLookup(_ => _), false },
+            { new Dictionary<string, int>().Keys, true },
+            { new Dictionary<string, int> { { "a", 1 } }.Values, false },
+            // A lazy sequence is not treated as a collection at all, empty or not
+            { new[] { 1 }.Where(_ => false), false }
         };
     }
 }

--- a/src/Verify/Serialization/ReflectionHelpers.cs
+++ b/src/Verify/Serialization/ReflectionHelpers.cs
@@ -98,44 +98,71 @@ static class ReflectionHelpers
             return false;
         }
 
-        var type = target.GetType();
+        switch (enumerableKinds.GetOrAdd(target.GetType(), GetEnumerableKind))
+        {
+            case EnumerableKind.AlwaysEmpty:
+                enumerable = enumerableTarget;
+                isEmpty = true;
+                return true;
+            case EnumerableKind.Enumerate:
+                enumerable = enumerableTarget;
+                isEmpty = IsEmpty(enumerableTarget);
+                return true;
+            default:
+                enumerable = null;
+                isEmpty = null;
+                return false;
+        }
+    }
+
+    enum EnumerableKind
+    {
+        NotACollection,
+        AlwaysEmpty,
+        Enumerate
+    }
+
+    /// <summary>
+    /// Whether a value is a collection depends only on its type, but the answer used to be
+    /// recomputed for every value. With the default ignoreEmptyCollections this runs for
+    /// every non null member value, array item and dictionary value, and for anything that
+    /// is not a non generic ICollection (every HashSet, dictionary key and value view,
+    /// iterator, LINQ result and immutable collection) it allocated a fresh Type[] from
+    /// GetInterfaces plus several LINQ passes over it. Only the per value IsEmpty
+    /// enumeration is left.
+    /// </summary>
+    static ConcurrentDictionary<Type, EnumerableKind> enumerableKinds = new();
+
+    static EnumerableKind GetEnumerableKind(Type type)
+    {
         if (type.IsEnumerableEmpty())
         {
-            enumerable = enumerableTarget;
-            isEmpty = true;
-            return true;
+            return EnumerableKind.AlwaysEmpty;
         }
 
-        if (type.FullName != null &&
-            type.FullName.StartsWith("System.Linq.ILookup", StringComparison.Ordinal))
+        if (IsLookup(type))
         {
-            enumerable = enumerableTarget;
-            isEmpty = IsEmpty(enumerable);
-            return true;
+            return EnumerableKind.Enumerate;
         }
 
         var interfaces = type.GetInterfaces();
 
-        if (interfaces.Any(_ => _.FullName != null &&
-                                _.FullName.StartsWith("System.Linq.ILookup", StringComparison.Ordinal)))
+        if (interfaces.Any(IsLookup))
         {
-            enumerable = enumerableTarget;
-            isEmpty = IsEmpty(enumerable);
-            return true;
+            return EnumerableKind.Enumerate;
         }
 
         if (type.ImplementsGenericCollection() ||
             interfaces.Any(ImplementsGenericCollection))
         {
-            enumerable = enumerableTarget;
-            isEmpty = IsEmpty(enumerable);
-            return true;
+            return EnumerableKind.Enumerate;
         }
 
-        enumerable = null;
-        isEmpty = null;
-        return false;
+        return EnumerableKind.NotACollection;
     }
+
+    static bool IsLookup(Type type) =>
+        type.FullName?.StartsWith("System.Linq.ILookup", StringComparison.Ordinal) == true;
 
     static bool IsEmpty(IEnumerable enumerable)
     {


### PR DESCRIPTION
Whether a value is a collection depends only on its type, but it was recomputed per value. With the default ignoreEmptyCollections this runs for every non null member value, array item and dictionary value, and anything that is not a non generic ICollection (every HashSet, dictionary key and value view, iterator, LINQ result and immutable collection) allocated a fresh Type[] from GetInterfaces and then made several LINQ passes over it with FullName string comparisons, for every occurrence of the same type.

The classification is now held in a ConcurrentDictionary keyed by type, leaving only the per value IsEmpty enumeration.

The added test cases all sit below the ICollection fast path, so they exercise the classification, and they pass unchanged against the previous implementation.