### PR TITLE
Stop copied settings sharing mutations of the source serialization

### DIFF
--- a/src/Verify.Tests/CopyConstructorTests.cs
+++ b/src/Verify.Tests/CopyConstructorTests.cs
@@ -43,6 +43,36 @@ public class CopyConstructorTests
     }
 
     [Fact]
+    public void SerializationMutationAfterCopyDoesNotLeak()
+    {
+        var settings = new VerifySettings();
+        // The first mutation clones the global serialization settings, so from here the
+        // instance owns them and mutates in place.
+        settings.IgnoreMember("First");
+
+        var copy = new VerifySettings(settings);
+        settings.IgnoreMember("Second");
+
+        Assert.True(copy.serialization.ShouldIgnoreByName("First"));
+        // Mutating the source after the copy was taken must not reach the copy.
+        Assert.False(copy.serialization.ShouldIgnoreByName("Second"));
+        Assert.True(settings.serialization.ShouldIgnoreByName("Second"));
+    }
+
+    [Fact]
+    public void SerializationMutationOnCopyDoesNotLeak()
+    {
+        var settings = new VerifySettings();
+        settings.IgnoreMember("First");
+
+        var copy = new VerifySettings(settings);
+        copy.IgnoreMember("Second");
+
+        Assert.False(settings.serialization.ShouldIgnoreByName("Second"));
+        Assert.True(copy.serialization.ShouldIgnoreByName("Second"));
+    }
+
+    [Fact]
     public void ClonesExtensionMappedScrubbers()
     {
         var settings = new VerifySettings();

--- a/src/Verify/VerifySettings.cs
+++ b/src/Verify/VerifySettings.cs
@@ -63,7 +63,12 @@ public partial class VerifySettings
         inline = settings.inline;
         notInline = settings.notInline;
         throwException = settings.throwException;
+        // Copy on write: the copy shares the source's SerializationSettings until either
+        // of them mutates. Marking the source as no longer the exclusive owner makes it
+        // clone before its next mutation. Without that, a source that had already cloned
+        // keeps mutating in place, and those mutations leak into this copy.
         serialization = settings.serialization;
+        settings.isCloned = false;
         stringComparer = settings.stringComparer;
         streamComparer = settings.streamComparer;
         extensionStringComparers = settings.extensionStringComparers == null ? null : new(settings.extensionStringComparers);


### PR DESCRIPTION
SerializationSettings is copy on write: the first serialization mutation on a VerifySettings clones the global instance and sets isCloned, after which that instance mutates its own copy in place.

The copy constructor assigned that same instance to the copy without clearing isCloned on the source, so every later mutation of the source was applied in place and observed by the copy:

    settings.IgnoreMember("A");
    var copy = new VerifySettings(settings);
    settings.IgnoreMember("B"); // also ignored by copy

This also hit the eager copy the SettingsTask constructor takes, when the original settings were mutated between two Verify calls.

The source is now marked as no longer the exclusive owner, so it clones before its next mutation. Sharing until either side writes keeps the copy allocation free, which matters since a copy is taken per verification.