### PR TITLE
Format fallback parameter names with the invariant culture

### DIFF
--- a/src/Verify.Tests/Naming/NameForParameterTests.cs
+++ b/src/Verify.Tests/Naming/NameForParameterTests.cs
@@ -33,6 +33,28 @@
         Assert.Contains("a/b", name);
     }
 
+    // Types not in parameterToNameLookup fall back to formatting the value, which must
+    // not vary by machine culture. sv-SE renders a negative number with U+2212 MINUS
+    // SIGN under ICU, so a theory case would name its files differently than on CI.
+    [Theory]
+    [InlineData("sv-SE")]
+    [InlineData("en-US")]
+    public void NegativeSbyteIsInvariant(string cultureName)
+    {
+        var original = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new(cultureName);
+        try
+        {
+            Assert.Equal(
+                "-5",
+                VerifierSettings.GetNameForParameter((sbyte) -5, counter: CounterBuilder.Empty()));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
     [Fact]
     public Task Int() =>
         Verify(VerifierSettings.GetNameForParameter(10, counter: CounterBuilder.Empty()));

--- a/src/Verify/Naming/VerifierSettings.cs
+++ b/src/Verify/Naming/VerifierSettings.cs
@@ -162,7 +162,13 @@ public static partial class VerifierSettings
                 continue;
             }
 
-            var nameForParameter = parameter.ToString();
+            // Invariant for anything formattable, so a file name never varies by machine
+            // culture. parameterToNameLookup covers the common types, but not sbyte,
+            // Int128, UInt128, BigInteger, nint or nuint, and under sv-SE a negative
+            // value of any of those renders with U+2212 MINUS SIGN instead of '-'.
+            var nameForParameter = parameter is IFormattable formattable
+                ? formattable.ToString(null, Culture.InvariantCulture)
+                : parameter.ToString();
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             if (nameForParameter is null)
             {


### PR DESCRIPTION
parameterToNameLookup pins invariant formatting for the common types, but not sbyte, Int128, UInt128, BigInteger, nint or nuint. Those fell through to parameter.ToString(), which uses the ambient culture: under sv-SE with ICU ((sbyte)-5).ToString() is '\u22125' with U+2212 MINUS SIGN, so a theory parameterised on a negative value of one of those types named its received and verified files differently than the same test on CI.

Fixed at the fallback rather than by extending the type list, so any formattable type is covered instead of only the ones someone remembered to add.