### PR TITLE
Release named recording state on dispose

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -25,7 +25,7 @@ public Task Usage()
     return Verify("TheValue");
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L54-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-Recording' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L84-L94' title='Snippet source file'>snippet source</a> | <a href='#snippet-Recording' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:
@@ -61,7 +61,7 @@ public Task TryAdd()
     return Verify("TheValue");
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L90-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingTryAdd' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L120-L132' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingTryAdd' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -85,7 +85,7 @@ public Task RecordingScoped()
     return Verify();
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L113-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingScoped' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L143-L158' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingScoped' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:
@@ -117,7 +117,7 @@ public Task SameKey()
     return Verify("TheValue");
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L312-L323' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingSameKey' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L342-L353' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingSameKey' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:
@@ -156,7 +156,7 @@ public Task Identifier()
     return Verify(Recording.Stop("identifier"));
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L130-L140' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingIdentifier' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L160-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingIdentifier' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:
@@ -188,7 +188,7 @@ public Task Case()
     return Verify("TheValue");
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L334-L345' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingIgnoreCase' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L364-L375' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingIgnoreCase' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:
@@ -223,7 +223,7 @@ public Task Stop()
     return Verify(appends.Where(_ => _.Name != "name1"));
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L172-L184' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingStop' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L202-L214' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingStop' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:
@@ -255,7 +255,7 @@ public Task StopNotInResult()
     return Verify("other data");
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L186-L198' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingStopNotInResult' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L216-L228' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingStopNotInResult' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:
@@ -284,7 +284,7 @@ public void IsRecording()
     Assert.True(Recording.IsRecording());
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L142-L152' title='Snippet source file'>snippet source</a> | <a href='#snippet-IsRecording' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L172-L182' title='Snippet source file'>snippet source</a> | <a href='#snippet-IsRecording' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This can be helpful if the cost of capturing data, to add to recording, is high.
@@ -307,7 +307,7 @@ public Task Clear()
     return Verify();
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L232-L244' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingClear' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L262-L274' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingClear' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:
@@ -343,7 +343,7 @@ public Task PauseResume()
     return Verify();
 }
 ```
-<sup><a href='/src/Verify.Tests/RecordingTests.cs#L256-L271' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingPauseResume' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.Tests/RecordingTests.cs#L286-L301' title='Snippet source file'>snippet source</a> | <a href='#snippet-RecordingPauseResume' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Results in:

--- a/src/Verify.Tests/RecordingTests.cs
+++ b/src/Verify.Tests/RecordingTests.cs
@@ -41,6 +41,36 @@
         }
     }
 
+    // Named state lives in a static dictionary, so a scope left without an explicit Stop,
+    // for example because the test threw, would otherwise hold it and its recorded objects
+    // forever, and block the identifier for every later Start.
+    [Fact]
+    public void DisposeNamedReleasesTheIdentifier()
+    {
+        try
+        {
+            using (Recording.Start("DisposeNamedReleases"))
+            {
+                Recording.Add("DisposeNamedReleases", "name", "value");
+                throw new("test failure");
+            }
+        }
+        catch (Exception exception)
+            when (exception.Message == "test failure")
+        {
+        }
+
+        Assert.False(Recording.IsRecording("DisposeNamedReleases"));
+
+        // The identifier is free again
+        using (Recording.Start("DisposeNamedReleases"))
+        {
+            Recording.Add("DisposeNamedReleases", "name", "value2");
+            var recorded = Recording.Stop("DisposeNamedReleases");
+            Assert.Equal(["value2"], recorded.Select(_ => _.Data));
+        }
+    }
+
     [Fact]
     public Task Dates()
     {

--- a/src/Verify/Recording/Recording_Named.cs
+++ b/src/Verify/Recording/Recording_Named.cs
@@ -75,10 +75,14 @@ public static partial class Recording
     class NamedDisposable(string identifier) :
         IDisposable
     {
-        // TryPause (not Pause) so disposing after an explicit Stop is a no-op
-        // rather than throwing from CurrentStateNamed.
+        // Removed, not paused. Named state lives in a static dictionary, so unlike the
+        // unnamed variant nothing else can reclaim it: leaving it there holds every
+        // recorded object for the life of the process, and makes a later Start with the
+        // same identifier throw "Recording already started". Identifiers are meant to be
+        // statically unique, so that happens across theory cases or an in process re-run.
+        // A no-op after an explicit Stop, which has already removed it.
         public void Dispose() =>
-            TryPause(identifier);
+            namedState.TryRemove(identifier, out _);
     }
 
     public static void Pause(string identifier) =>


### PR DESCRIPTION
The named disposable only paused, so a scope left without an explicit Stop, for example because the test threw, left the State and every object it had recorded reachable forever through the static namedState dictionary. The unnamed variant is reclaimed with its execution context, but named state has nothing to reclaim it.

It also blocked the identifier: identifiers are documented as statically unique, such as a fully qualified test name, so the next Start with the same one threw 'Recording already started', masking the original failure.

Dispose now removes the entry, which stays a no-op after an explicit Stop.