### PR TITLE
Compile the MSTest generator against the Roslyn version it is packed for

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,15 @@
     <ImportVerifyMsbuildFiles Condition="'$(MSBuildProjectName)' != '' And $(MSBuildProjectName.EndsWith('Tests'))">true</ImportVerifyMsbuildFiles>
     <!-- Work around https://github.com/dotnet/sdk/issues/51265#issuecomment-3407578810 -->
     <RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
+    <!-- The Roslyn version the MSTest source generator compiles against, and the analyzers
+         folder Verify.MSTest packs it into. The two have to agree: a generator compiled
+         against a higher version than its folder claims is loaded by every compiler in
+         between and then skipped with CS9057, which silently disables [UsesVerify] and
+         surfaces only as "TestContext is null" at run time. Kept here so neither can move
+         without the other. Lower means more compilers are supported, so raise it only for
+         an API the generator actually needs.
+         https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support -->
+    <VerifyRoslynVersion>4.4</VerifyRoslynVersion>
   </PropertyGroup>
   <!-- This directory contains two solutions (Verify.slnx and VerifyDangling.slnx), so Verify cannot
        auto-discover the solution when a project is built outside of a solution context. Default to the

--- a/src/Verify.MSTest.SourceGenerator/Verify.MSTest.SourceGenerator.csproj
+++ b/src/Verify.MSTest.SourceGenerator/Verify.MSTest.SourceGenerator.csproj
@@ -9,13 +9,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <!-- Overrides the central version, which the rest of the solution uses to consume
+         Roslyn. This assembly is loaded by the consumer's compiler instead, so it is
+         compiled against the oldest Roslyn it supports: the one named by the analyzers
+         folder it is packed into. See VerifyRoslynVersion in Directory.Build.props. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" VersionOverride="$(VerifyRoslynVersion).0" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="CheckPackageVersion" BeforeTargets="Build">
-    <!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 -->
     <Error Condition="'%(PackageVersion.Identity)' == 'Microsoft.CodeAnalysis.Analyzers' AND '%(PackageVersion.Version)' != '3.11.0'" Text="Invalid package version for Microsoft.CodeAnalysis.Analyzers. Expected: 3.11.0." />
-    <Error Condition="'%(PackageVersion.Identity)' == 'Microsoft.CodeAnalysis.CSharp' AND '%(PackageVersion.Version)' != '4.14.0'" Text="Invalid package version for Microsoft.CodeAnalysis.CSharp. Expected: 4.14.0." />
   </Target>
 </Project>

--- a/src/Verify.MSTest/Verify.MSTest.csproj
+++ b/src/Verify.MSTest/Verify.MSTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net462;net472;net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
-    <RoslynVersion>4.4</RoslynVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Sbom.Targets" PrivateAssets="all" Condition="'$(CI)' == 'true'" />
@@ -16,7 +15,7 @@
     <None Include="buildTransitive\Verify.MSTest.props" Pack="true" PackagePath="build\" />
     <None Include="..\Verify.MSTest.SourceGenerator\bin\Release\netstandard2.0\Verify.MSTest.SourceGenerator.dll"
           Pack="true"
-          PackagePath="analyzers\dotnet\roslyn$(RoslynVersion)\cs\" />
+          PackagePath="analyzers\dotnet\roslyn$(VerifyRoslynVersion)\cs\" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.IO.Compression" />


### PR DESCRIPTION
The generator was packed only into analyzers/dotnet/roslyn4.4, but its Microsoft.CodeAnalysis.CSharp reference had been bumped to 4.14.0 without the folder moving with it.

Every compiler from 4.4 up to 4.13 therefore selected that folder and then skipped the assembly with CS9057, which is a warning. So [UsesVerify] generated nothing and each Verify call failed at run time with 'TestContext is null. Ensure test class has a [UsesVerify] attribute'. That covers VS 17.8 to 17.13, the .NET 8 LTS SDK, and .NET 9 SDKs before 9.0.300.

The generator now compiles against 4.4 again, restoring the support floor the folder always claimed. It only uses APIs from 4.3 and earlier (ForAttributeWithMetadataName, WithTrackingName), so nothing is given up.

Both the reference and the pack path now read one VerifyRoslynVersion property, so they cannot drift apart again. This replaces the CheckPackageVersion guard on Microsoft.CodeAnalysis.CSharp, which asserted the central version that this project no longer uses.