### PR TITLE
Resolve the OS platform on demand

### DIFF
--- a/src/Verify/Naming/Namer.cs
+++ b/src/Verify/Naming/Namer.cs
@@ -151,7 +151,6 @@ public class Namer
         Architecture = RuntimeInformation
             .ProcessArchitecture.ToString()
             .ToLowerInvariant();
-        OperatingSystemPlatform = GetOsPlatform();
     }
 
     static string GetOsPlatform()
@@ -181,7 +180,7 @@ public class Namer
             return "IOS";
         }
 
-        throw new("Unknown OS");
+        throw new($"Unknown OS: {RuntimeInformation.OSDescription}. UniqueForOSPlatform cannot name this platform.");
     }
 
     public static string Runtime { get; }
@@ -190,7 +189,16 @@ public class Namer
 
     public static string Architecture { get; }
 
-    public static string OperatingSystemPlatform { get; }
+    static string? operatingSystemPlatform;
+
+    /// <summary>
+    /// Resolved on demand rather than in the static constructor. GetOsPlatform throws for
+    /// any platform outside the handful it names, and VerifySettings creates a Namer, so
+    /// resolving eagerly failed every verification on an unrecognized platform
+    /// (FreeBSD, browser-wasm, tvOS) with a TypeInitializationException, even for tests
+    /// that never asked for UniqueForOSPlatform.
+    /// </summary>
+    public static string OperatingSystemPlatform => operatingSystemPlatform ??= GetOsPlatform();
 
     internal Namer()
     {


### PR DESCRIPTION
GetOsPlatform throws for any platform outside Linux, Windows, OSX, Android and iOS, and it ran from the Namer static constructor. VerifySettings creates a Namer, so on FreeBSD, browser-wasm or tvOS every verification failed with a TypeInitializationException, including the tests that never asked for UniqueForOSPlatform.

It is now resolved by the property, which only PrefixUnique reads, and only when UniqueForOSPlatform is actually set. The message also names the platform now, since 'Unknown OS' gave nothing to act on.