### PR TITLE
Describe the real Fixie setup in the No State found error

### DIFF
--- a/src/Verify.Fixie/Execution/ExecutionState.cs
+++ b/src/Verify.Fixie/Execution/ExecutionState.cs
@@ -25,9 +25,10 @@ public class ExecutionState(TestClass testClass, Test test, object[]? parameters
 
             throw new(
                 """
-                No State found. Ensure a class inheriting from VerifyTestProject exists in the test project.
-                public class TestProject :
-                    VerifyTestProject;
+                No State found. Fixie leaves test execution up to the consumer, so Verify needs a class in the test project implementing Fixie's ITestProject and IExecution:
+                  * ITestProject.Configure must call VerifierSettings.AssignTargetAssembly(environment.Assembly)
+                  * IExecution.Run must wrap each test.Run in `using (ExecutionState.Set(testClass, test, parameters))`
+                See https://github.com/VerifyTests/Verify/blob/main/docs/mdsource/fixie-convention.include.md for a full example.
                 """);
         }
     }


### PR DESCRIPTION
The message told users to inherit from VerifyTestProject, a type that does not exist in the package, the repo, or the docs. It fires exactly when a user has not wired Verify into Fixie yet, so it sent them looking for a base class that was never there.

It now states the actual requirement: implement Fixie's ITestProject and IExecution, assign the target assembly, and wrap each run in ExecutionState.Set.