### PR TITLE
Run before callbacks from the file level InnerVerifier constructor

### DIFF
--- a/src/Verify.Tests/InnerVerifyTests/InnerVerifyTests.cs
+++ b/src/Verify.Tests/InnerVerifyTests/InnerVerifyTests.cs
@@ -24,6 +24,25 @@ public class InnerVerifyTests
 
     #endregion
 
+    // Dispose runs the after callbacks, so this constructor has to run the before half
+    // too. An unbalanced pair leaves whatever it pushes, sets or counts in the wrong state.
+    [Fact]
+    public void RunsBeforeAndAfterCallbacks()
+    {
+        var calls = new List<string>();
+        var settings = new VerifySettings();
+        settings.OnVerify(
+            before: () => calls.Add("before"),
+            after: () => calls.Add("after"));
+
+        using (new InnerVerifier(targetDirectory, "callbackBalance", settings))
+        {
+            Assert.Equal(["before"], calls);
+        }
+
+        Assert.Equal(["before", "after"], calls);
+    }
+
     [Fact]
     public async Task VerifyExternalFileLocked()
     {

--- a/src/Verify/Verifier/InnerVerifier.cs
+++ b/src/Verify/Verifier/InnerVerifier.cs
@@ -196,6 +196,12 @@ public partial class InnerVerifier :
             this.settings = settings;
         }
 
+        // Dispose runs the after callbacks unconditionally, so the before callbacks have
+        // to run here too. Otherwise an OnVerify(before, after) pair registered by a
+        // consumer of this API has its after half executed unbalanced, leaving whatever
+        // the pair pushes, sets or counts in the wrong state.
+        this.settings.RunBeforeCallbacks();
+
         SetVerifyHasBeenRun(name);
 
         this.directory = directory;


### PR DESCRIPTION
Dispose calls RunAfterCallbacks unconditionally, and the primary constructor calls RunBeforeCallbacks, but the constructor used by third party clients to verify a file directly never did.

So an OnVerify(before, after) pair registered against those settings, or globally, had only its after half executed. Anything the pair sets and restores, such as a culture, ambient state or a counter, was left unbalanced.