### PR TITLE
Never report the current process as locking a file

### DIFF
--- a/src/Verify.Tests/FileLockKillerTests.cs
+++ b/src/Verify.Tests/FileLockKillerTests.cs
@@ -11,4 +11,35 @@ public class FileLockKillerTests
     [Fact]
     public Task ParseEnvironmentVariable_failure() =>
         Throws(() => FileLockKiller.ParseEnvironmentVariable("foo"));
+
+    // RmGetList reports the caller too when the lock is held in process. Killing that
+    // would kill the test run, so the current process must never be returned.
+    [Fact]
+    public void CurrentProcessIsNotReported()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        using var file = new TempFile(".txt");
+        File.WriteAllText(file, "content");
+
+        // ReSharper disable once UseAwaitUsing
+        using var locker = new FileStream(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        var processes = RestartManager.GetProcessesLockingFile(file);
+        try
+        {
+            using var current = Process.GetCurrentProcess();
+            Assert.DoesNotContain(processes, _ => _.Id == current.Id);
+        }
+        finally
+        {
+            foreach (var process in processes)
+            {
+                process.Dispose();
+            }
+        }
+    }
 }

--- a/src/Verify/RestartManager.cs
+++ b/src/Verify/RestartManager.cs
@@ -112,11 +112,23 @@ static class RestartManager
                 return processes;
             }
 
+            using var currentProcess = Process.GetCurrentProcess();
+            var currentProcessId = currentProcess.Id;
             for (var i = 0; i < pnProcInfo; i++)
             {
+                var processId = processInfo[i].Process.dwProcessId;
+
+                // RmGetList reports the caller too when the lock is held in process, for
+                // example by test code holding the file open. Killing that is killing the
+                // test run, and the write being retried could not have succeeded anyway.
+                if (processId == currentProcessId)
+                {
+                    continue;
+                }
+
                 try
                 {
-                    var process = Process.GetProcessById(processInfo[i].Process.dwProcessId);
+                    var process = Process.GetProcessById(processId);
                     processes.Add(process);
                 }
                 catch (ArgumentException)


### PR DESCRIPTION
RmGetList includes the caller when the lock is held in process, which the new test confirms. FileLockKiller kills everything the list reports, so with Verify_KillProcessLockingFile enabled a file held open inside the test process made the test host kill itself: the run vanished with no diagnostics, and the write being retried could not have succeeded anyway.

The docs describe the target as external editor and diff processes, so the current process id is now skipped.