### PR TITLE
Always write an object for ClaimsPrincipal

### DIFF
--- a/src/Verify.Tests/Serialization/ClaimsTests.ClaimsPrincipalWithIdentity.verified.txt
+++ b/src/Verify.Tests/Serialization/ClaimsTests.ClaimsPrincipalWithIdentity.verified.txt
@@ -1,0 +1,15 @@
+﻿{
+  Principal: {
+    Identities: [
+      {
+        Claims: [
+          {
+            TheClaimType: TheClaimValue
+          }
+        ],
+        AuthenticationType: TheAuthenticationType
+      }
+    ]
+  },
+  Name: TheValue
+}

--- a/src/Verify.Tests/Serialization/ClaimsTests.EmptyClaimsPrincipal.verified.txt
+++ b/src/Verify.Tests/Serialization/ClaimsTests.EmptyClaimsPrincipal.verified.txt
@@ -1,0 +1,4 @@
+﻿{
+  Principal: {},
+  Name: TheValue
+}

--- a/src/Verify.Tests/Serialization/ClaimsTests.cs
+++ b/src/Verify.Tests/Serialization/ClaimsTests.cs
@@ -1,0 +1,25 @@
+public class ClaimsTests
+{
+    [Fact]
+    public Task EmptyClaimsPrincipal() =>
+        // An empty principal still writes an object. Writing no token would leave the
+        // writer mid-property and corrupt every member written after it.
+        Verify(
+            new
+            {
+                Principal = new ClaimsPrincipal(),
+                Name = "TheValue"
+            });
+
+    [Fact]
+    public Task ClaimsPrincipalWithIdentity() =>
+        Verify(
+            new
+            {
+                Principal = new ClaimsPrincipal(
+                    new ClaimsIdentity(
+                        [new Claim("TheClaimType", "TheClaimValue")],
+                        "TheAuthenticationType")),
+                Name = "TheValue"
+            });
+}

--- a/src/Verify/Serialization/Converters/ClaimsPrincipalConverter.cs
+++ b/src/Verify/Serialization/Converters/ClaimsPrincipalConverter.cs
@@ -5,11 +5,10 @@ class ClaimsPrincipalConverter :
 {
     public override void Write(VerifyJsonWriter writer, ClaimsPrincipal principal)
     {
-        if (!principal.Identities.Any())
-        {
-            return;
-        }
-
+        // The object is always written, even with no identities. Writing no token at all
+        // leaves the writer in Property state after the caller has written the member
+        // name, which corrupts every subsequent write. WriteMember drops the empty
+        // Identities collection, so an empty principal renders as {}.
         writer.WriteStartObject();
         writer.WriteMember(principal, principal.Identities, "Identities");
         writer.WriteEndObject();


### PR DESCRIPTION
An empty ClaimsPrincipal returned without writing any token, which left the writer in Property state after the caller had written the member name. That threw JsonWriterException for a following member, silently emitted null in trailing position, and produced empty output at the root.

The object is now always written. WriteMember drops the empty Identities collection, so an empty principal renders as {}.