### PR TITLE
Do not let a clipboard failure replace the snapshot diff

### DIFF
--- a/src/Verify.ClipboardAccept/ClipboardAccept.cs
+++ b/src/Verify.ClipboardAccept/ClipboardAccept.cs
@@ -111,11 +111,28 @@ public static class ClipboardAccept
         try
         {
             builder.AppendLine(command);
-            await ClipboardService.SetTextAsync(builder.ToString());
+            await SetClipboardText(builder.ToString());
         }
         finally
         {
             semaphore.Release();
+        }
+    }
+
+    static async Task SetClipboardText(string text)
+    {
+        try
+        {
+            await ClipboardService.SetTextAsync(text);
+        }
+        catch (Exception exception)
+        {
+            // This runs from the OnFirstVerify and OnVerifyMismatch callbacks, which the
+            // engine awaits while building the failure. Letting a clipboard failure out
+            // replaces the snapshot diff with an unrelated error: no xsel or wl-copy on a
+            // headless Linux box, or another process holding the Windows clipboard.
+            // Copying the accept command is a convenience, so it fails quietly.
+            Trace.WriteLine($"Verify: could not write the accept command to the clipboard. {exception}");
         }
     }
 }


### PR DESCRIPTION
The clipboard write runs from the OnFirstVerify and OnVerifyMismatch callbacks, which the engine awaits while building the failure, and nothing guarded it. So ClipboardService throwing replaced the snapshot diff with an unrelated error: no xsel or wl-copy on a headless Linux box, or another process holding the Windows clipboard.

That is the same failure mode ClipboardEnabled already avoids for its environment variable parse. Copying the accept command is a convenience, so it now fails quietly to Trace.

No test: making ClipboardService fail on demand needs an environment without a clipboard, and the alternative is injecting a writer purely to exercise a try/catch.