### PR TITLE
Nest snapshots under razor parents and Content items

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -934,26 +934,41 @@ This readme will not discuss definitive list of details for proper setup of the 
 
 ## Project inclusion for `*.received.*` and `*.verified.*` files
 
-Verify comes with default MSBuild includes for snapshot files (`*.received.*` and `*.verified.*`) that nests those files under the test that produced them. C#, VB and F# projects are supported.
+Verify comes with default MSBuild includes for snapshot files (`*.received.*` and `*.verified.*`) that nests those files under the test that produced them. C#, VB and F# projects are supported. In Blazor projects, snapshots nest under the `.razor.cs` code-behind of the component under test, or under the `.razor` file when that component has no code-behind.
 
 <!-- snippet: Verify.AfterMicrosoftNetSdk.props -->
 <a id='snippet-Verify.AfterMicrosoftNetSdk.props'></a>
 ```props
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+  Probing for a Blazor parent costs a file system hit per snapshot file, so it is only done in
+  projects that contain razor files. A code behind is included in that, since a test class can sit
+  in one without the project holding the matching .razor.
+  -->
+  <ItemGroup Condition="('$(DisableVerifyFileNesting)' != 'true') And $(Language) == 'C#'">
+    <VerifyRazorFile Include="**\*.razor;**\*.razor.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+  </ItemGroup>
+  <PropertyGroup Condition="('$(DisableVerifyFileNesting)' != 'true')">
+    <VerifyRazorFileCount>@(VerifyRazorFile->Count())</VerifyRazorFileCount>
+  </PropertyGroup>
   <ItemGroup Condition="('$(DisableVerifyFileNesting)' != 'true')">
-    <None Include="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'C#'">
+    <None Include="**\*.received.*;**\*.verified.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'C#'">
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
-      <DependentUpon>%(ParentFile).cs</DependentUpon>
+      <ParentExtension>.cs</ParentExtension>
+      <!-- A Blazor component keeps its code in a .razor.cs code-behind, or in the .razor file itself -->
+      <ParentExtension Condition="'$(VerifyRazorFileCount)' != '0' And Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).razor.cs')">.razor.cs</ParentExtension>
+      <ParentExtension Condition="'$(VerifyRazorFileCount)' != '0' And '%(ParentExtension)' == '.cs' And !Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).cs') And Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).razor')">.razor</ParentExtension>
+      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
     </None>
-    <None Include="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'VB'">
+    <None Include="**\*.received.*;**\*.verified.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'VB'">
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
       <DependentUpon>%(ParentFile).vb</DependentUpon>
     </None>
   </ItemGroup>
 </Project>
 ```
-<sup><a href='/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props#L1-L13' title='Snippet source file'>snippet source</a> | <a href='#snippet-Verify.AfterMicrosoftNetSdk.props' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props#L1-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-Verify.AfterMicrosoftNetSdk.props' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To opt out of this feature, include the following in the project file:

--- a/readme.source.md
+++ b/readme.source.md
@@ -383,7 +383,7 @@ This readme will not discuss definitive list of details for proper setup of the 
 
 ## Project inclusion for `*.received.*` and `*.verified.*` files
 
-Verify comes with default MSBuild includes for snapshot files (`*.received.*` and `*.verified.*`) that nests those files under the test that produced them. C#, VB and F# projects are supported.
+Verify comes with default MSBuild includes for snapshot files (`*.received.*` and `*.verified.*`) that nests those files under the test that produced them. C#, VB and F# projects are supported. In Blazor projects, snapshots nest under the `.razor.cs` code-behind of the component under test, or under the `.razor` file when that component has no code-behind.
 
 snippet: Verify.AfterMicrosoftNetSdk.props
 

--- a/src/Verify.Tests/FileNestingTests.CSharpProject.verified.txt
+++ b/src/Verify.Tests/FileNestingTests.CSharpProject.verified.txt
@@ -1,0 +1,6 @@
+﻿None
+  Tests.Simple.received.txt: Tests.cs
+  Tests.Simple.verified.json: Tests.cs
+  Tests.Simple.verified.txt: Tests.cs
+Content
+  none

--- a/src/Verify.Tests/FileNestingTests.ProjectWithOnlyACodeBehind.verified.txt
+++ b/src/Verify.Tests/FileNestingTests.ProjectWithOnlyACodeBehind.verified.txt
@@ -1,0 +1,5 @@
+﻿None
+  CodeBehindTests.Component.verified.html: CodeBehindTests.razor.cs
+  CodeBehindTests.Component.verified.txt: CodeBehindTests.razor.cs
+Content
+  none

--- a/src/Verify.Tests/FileNestingTests.RazorProject.verified.txt
+++ b/src/Verify.Tests/FileNestingTests.RazorProject.verified.txt
@@ -1,0 +1,7 @@
+﻿None
+  ComponentTests.Simple.verified.html: ComponentTests.razor.cs
+  NoCodeBehindTests.Simple.verified.html: NoCodeBehindTests.razor
+  PlainTests.Simple.verified.txt: PlainTests.cs
+  Sub/SubComponentTests.Simple.verified.html: SubComponentTests.razor.cs
+Content
+  ComponentTests.Simple.verified.json: ComponentTests.razor.cs

--- a/src/Verify.Tests/FileNestingTests.RazorProjectWithNestingDisabled.verified.txt
+++ b/src/Verify.Tests/FileNestingTests.RazorProjectWithNestingDisabled.verified.txt
@@ -1,0 +1,4 @@
+﻿None
+  ComponentTests.Simple.verified.html: not nested
+Content
+  ComponentTests.Simple.verified.json: not nested

--- a/src/Verify.Tests/FileNestingTests.VisualBasicProject.verified.txt
+++ b/src/Verify.Tests/FileNestingTests.VisualBasicProject.verified.txt
@@ -1,0 +1,4 @@
+﻿None
+  Tests.Simple.verified.txt: Tests.vb
+Content
+  none

--- a/src/Verify.Tests/FileNestingTests.WebProject.verified.txt
+++ b/src/Verify.Tests/FileNestingTests.WebProject.verified.txt
@@ -1,0 +1,6 @@
+﻿None
+  Tests.Simple.verified.txt: Tests.cs
+Content
+  Tests.Explicit.verified.json: Other.cs
+  Tests.Simple.verified.config: Tests.cs
+  Tests.Simple.verified.json: Tests.cs

--- a/src/Verify.Tests/FileNestingTests.cs
+++ b/src/Verify.Tests/FileNestingTests.cs
@@ -1,0 +1,250 @@
+#if NET10_0
+
+using System.Text.Json;
+
+// Snapshot nesting is applied during evaluation, because evaluated items are what Solution Explorer
+// reads. So these tests evaluate a project and inspect its items, rather than building it.
+public class FileNestingTests
+{
+    [Fact]
+    public async Task CSharpProject() =>
+        await Verify(
+            await Evaluate(
+                CSharp("Microsoft.NET.Sdk"),
+                "Tests.cs",
+                "Tests.Simple.verified.txt",
+                // outside the razor and web SDKs, json snapshots are None like any other extension
+                "Tests.Simple.verified.json",
+                "Tests.Simple.received.txt",
+                // a snapshot copied to the intermediate directory is not part of the project
+                "obj/Debug/net10.0/Tests.Simple.verified.txt"));
+
+    [Fact]
+    public async Task RazorProject() =>
+        await Verify(
+            await Evaluate(
+                CSharp("Microsoft.NET.Sdk.Razor"),
+                // a component with a code behind: snapshots nest under the code behind
+                "ComponentTests.razor",
+                "ComponentTests.razor.cs",
+                "ComponentTests.Simple.verified.html",
+                // the razor and web SDKs claim json as Content rather than None
+                "ComponentTests.Simple.verified.json",
+                // a component without a code behind: the snapshot nests under the razor file
+                "NoCodeBehindTests.razor",
+                "NoCodeBehindTests.Simple.verified.html",
+                // a component in a sub directory
+                "Sub/SubComponentTests.razor",
+                "Sub/SubComponentTests.razor.cs",
+                "Sub/SubComponentTests.Simple.verified.html",
+                // a plain test class in a razor project still nests under the cs file
+                "PlainTests.cs",
+                "PlainTests.Simple.verified.txt"));
+
+    // A test class can sit in a code behind whose component lives in the project under test, so the
+    // project holding the test has the .razor.cs but not the .razor.
+    [Fact]
+    public async Task ProjectWithOnlyACodeBehind() =>
+        await Verify(
+            await Evaluate(
+                CSharp("Microsoft.NET.Sdk"),
+                "CodeBehindTests.razor.cs",
+                "CodeBehindTests.Component.verified.html",
+                "CodeBehindTests.Component.verified.txt"));
+
+    [Fact]
+    public async Task RazorProjectWithNestingDisabled() =>
+        await Verify(
+            await Evaluate(
+                CSharp(
+                    "Microsoft.NET.Sdk.Razor",
+                    properties: "<DisableVerifyFileNesting>true</DisableVerifyFileNesting>"),
+                "ComponentTests.razor",
+                "ComponentTests.razor.cs",
+                "ComponentTests.Simple.verified.html",
+                "ComponentTests.Simple.verified.json"));
+
+    [Fact]
+    public async Task WebProject() =>
+        await Verify(
+            await Evaluate(
+                CSharp(
+                    "Microsoft.NET.Sdk.Web",
+                    body:
+                    """
+                      <ItemGroup>
+                        <Content Update="Tests.Explicit.verified.json" DependentUpon="Other.cs" />
+                      </ItemGroup>
+                    """),
+                "Tests.cs",
+                "Other.cs",
+                // a web project has no razor files, so no parent is probed for
+                "Tests.Simple.verified.json",
+                "Tests.Simple.verified.config",
+                "Tests.Simple.verified.txt",
+                // an explicitly nested snapshot keeps the parent it was given
+                "Tests.Explicit.verified.json"));
+
+    [Fact]
+    public async Task VisualBasicProject() =>
+        await Verify(
+            await Evaluate(
+                VisualBasic(),
+                "Tests.vb",
+                "Tests.Simple.verified.txt"));
+
+    static (string file, string content) CSharp(string sdk, string properties = "", string body = "") =>
+        ("TestProject.csproj", ProjectContent(sdk, properties, body));
+
+    static (string file, string content) VisualBasic() =>
+        ("TestProject.vbproj", ProjectContent("Microsoft.NET.Sdk", "", ""));
+
+    static string ProjectContent(string sdk, string properties, string body) =>
+        $"""
+         <Project Sdk="{sdk}">
+           <PropertyGroup>
+             <TargetFramework>net10.0</TargetFramework>
+             {properties}
+           </PropertyGroup>
+         {body}
+         </Project>
+         """;
+
+    static async Task<string> Evaluate((string file, string content) project, params string[] files)
+    {
+        using var directory = new TempDirectory();
+        var path = directory.Path;
+
+        // The package imports these two through the buildTransitive convention, which lands them
+        // either side of the SDK. Directory.Build.props and .targets are those same two points.
+        await WriteFile(path, "Directory.Build.props", Import("Verify.props"));
+        await WriteFile(path, "Directory.Build.targets", Import("Verify.targets"));
+        await WriteFile(path, project.file, project.content);
+
+        foreach (var file in files)
+        {
+            await WriteFile(path, file, "");
+        }
+
+        return Format(await RunMsBuild(Path.Combine(path, project.file)));
+    }
+
+    static string Import(string file)
+    {
+        var full = Path.Combine(ProjectFiles.SolutionDirectory, "Verify", "buildTransitive", file);
+        return $"""
+                <Project>
+                  <Import Project="{full}" />
+                </Project>
+                """;
+    }
+
+    static async Task WriteFile(string directory, string relativePath, string content)
+    {
+        var path = Path.Combine(directory, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(path, content);
+    }
+
+    static string Format(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var items = document.RootElement.GetProperty("Items");
+        var builder = new StringBuilder();
+        string[] types = ["None", "Content"];
+        foreach (var type in types)
+        {
+            builder.AppendLine(type);
+
+            var snapshots = Snapshots(items, type);
+            if (snapshots.Count == 0)
+            {
+                builder.AppendLine("  none");
+                continue;
+            }
+
+            foreach (var snapshot in snapshots)
+            {
+                builder.AppendLine($"  {snapshot.Key}: {Parent(snapshot)}");
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    // Verify adds its own item for a snapshot on top of the one the SDK globbed, so the same file
+    // can appear more than once. Any disagreement between those items is a bug.
+    static string Parent(IEnumerable<(string Identity, string? Parent)> snapshot)
+    {
+        var parents = snapshot
+            .Select(_ => _.Parent)
+            .Where(_ => _ != null)
+            .Distinct()
+            .ToList();
+        if (parents.Count == 0)
+        {
+            return "not nested";
+        }
+
+        return string.Join(" and ", parents);
+    }
+
+    static List<IGrouping<string, (string Identity, string? Parent)>> Snapshots(JsonElement items, string type)
+    {
+        if (!items.TryGetProperty(type, out var ofType))
+        {
+            return [];
+        }
+
+        return ofType
+            .EnumerateArray()
+            .Select(_ => (
+                // MSBuild uses the platform separator, and these paths are part of the snapshot
+                Identity: _.GetProperty("Identity").GetString()!.Replace('\\', '/'),
+                Parent: _.TryGetProperty("DependentUpon", out var parent) ? parent.GetString() : null))
+            .Where(_ => _.Identity.Contains(".verified.") ||
+                        _.Identity.Contains(".received."))
+            .GroupBy(_ => _.Identity)
+            .OrderBy(_ => _.Key, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    static async Task<string> RunMsBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        var arguments = startInfo.ArgumentList;
+        arguments.Add("msbuild");
+        arguments.Add(projectPath);
+        arguments.Add("-getItem:None");
+        arguments.Add("-getItem:Content");
+        arguments.Add("-nologo");
+
+        using var process = Process.Start(startInfo)!;
+
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+
+        await process.WaitForExitAsync();
+
+        var output = await outputTask;
+        var error = await errorTask;
+
+        if (process.ExitCode == 0 &&
+            output.TrimStart().StartsWith('{'))
+        {
+            return output;
+        }
+
+        throw new($"Evaluation of {projectPath} failed:{Environment.NewLine}{output}{Environment.NewLine}{error}");
+    }
+}
+
+#endif

--- a/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props
+++ b/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props
@@ -1,11 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+  Probing for a Blazor parent costs a file system hit per snapshot file, so it is only done in
+  projects that contain razor files. A code behind is included in that, since a test class can sit
+  in one without the project holding the matching .razor.
+  -->
+  <ItemGroup Condition="('$(DisableVerifyFileNesting)' != 'true') And $(Language) == 'C#'">
+    <VerifyRazorFile Include="**\*.razor;**\*.razor.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+  </ItemGroup>
+  <PropertyGroup Condition="('$(DisableVerifyFileNesting)' != 'true')">
+    <VerifyRazorFileCount>@(VerifyRazorFile->Count())</VerifyRazorFileCount>
+  </PropertyGroup>
   <ItemGroup Condition="('$(DisableVerifyFileNesting)' != 'true')">
-    <None Include="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'C#'">
+    <None Include="**\*.received.*;**\*.verified.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'C#'">
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
-      <DependentUpon>%(ParentFile).cs</DependentUpon>
+      <ParentExtension>.cs</ParentExtension>
+      <!-- A Blazor component keeps its code in a .razor.cs code-behind, or in the .razor file itself -->
+      <ParentExtension Condition="'$(VerifyRazorFileCount)' != '0' And Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).razor.cs')">.razor.cs</ParentExtension>
+      <ParentExtension Condition="'$(VerifyRazorFileCount)' != '0' And '%(ParentExtension)' == '.cs' And !Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).cs') And Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).razor')">.razor</ParentExtension>
+      <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
     </None>
-    <None Include="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'VB'">
+    <None Include="**\*.received.*;**\*.verified.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'VB'">
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
       <DependentUpon>%(ParentFile).vb</DependentUpon>
     </None>

--- a/src/Verify/buildTransitive/Verify.targets
+++ b/src/Verify/buildTransitive/Verify.targets
@@ -10,4 +10,26 @@
       <DependentUpon>%(ParentFile).fs</DependentUpon>
     </None>
   </ItemGroup>
+  <!--
+  Snapshot files with an extension that the Razor and Web SDKs claim (eg .json and .config) are
+  Content instead of None. Those Content items only exist once the SDK props have been evaluated,
+  so, unlike the None nesting, they cannot be handled in Verify.AfterMicrosoftNetSdk.props.
+  -->
+  <ItemGroup Condition="('$(DisableVerifyFileNesting)' != 'true')">
+    <Content Update="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'C#'">
+      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
+      <ParentExtension>.cs</ParentExtension>
+      <ParentExtension Condition="'$(VerifyRazorFileCount)' != '0' And Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).razor.cs')">.razor.cs</ParentExtension>
+      <ParentExtension Condition="'$(VerifyRazorFileCount)' != '0' And '%(ParentExtension)' == '.cs' And !Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).cs') And Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).razor')">.razor</ParentExtension>
+      <DependentUpon Condition="'%(DependentUpon)' == ''">%(ParentFile)%(ParentExtension)</DependentUpon>
+    </Content>
+    <Content Update="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'VB'">
+      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
+      <DependentUpon Condition="'%(DependentUpon)' == ''">%(ParentFile).vb</DependentUpon>
+    </Content>
+    <Content Update="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'F#'">
+      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
+      <DependentUpon Condition="'%(DependentUpon)' == ''">%(ParentFile).fs</DependentUpon>
+    </Content>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
DependentUpon always pointed at <name>.cs. A Blazor test class sits in <name>.razor.cs, or in the <name>.razor itself, so nothing nested. The parent extension is now probed for, guarded on the project holding razor files so other projects pay nothing for it.

The razor and web SDKs claim extensions like .json and .config as Content and remove them from None. Those items only exist once the SDK props have been evaluated, so Content nesting is applied from Verify.targets, and only where nothing has already set a parent.

The snapshot glob also gained the default item excludes, so copies under bin and obj are no longer pulled into the project.

https://github.com/VerifyTests/Verify.Bunit/issues/108