### PR TITLE
Allow custom converters to override built-in converters

### DIFF
--- a/src/Verify.Tests/Serialization/SerializationSettingsTests.cs
+++ b/src/Verify.Tests/Serialization/SerializationSettingsTests.cs
@@ -1,0 +1,91 @@
+public class SerializationSettingsTests
+{
+    [Fact]
+    public void ExtraConverterOverridesBuiltIn()
+    {
+        var converter = new CustomEnumConverter();
+        var settings = new SerializationSettings();
+        settings.AddExtraSettings(_ => _.Converters.Add(converter));
+
+        AssertUsesConverter(settings, converter);
+        AssertUsesConverter(new(settings), converter);
+    }
+
+    [Fact]
+    public void ExtraSettingsPreserveOrder()
+    {
+        var first = new CustomEnumConverter();
+        var second = new CustomEnumConverter();
+        var settings = new SerializationSettings();
+        settings.AddExtraSettings(
+            _ =>
+            {
+                _.Converters.Add(first);
+                _.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+            });
+        settings.AddExtraSettings(
+            _ =>
+            {
+                Assert.Equal(ReferenceLoopHandling.Serialize, _.ReferenceLoopHandling);
+                _.Converters.Add(second);
+                _.ReferenceLoopHandling = ReferenceLoopHandling.Error;
+            });
+
+        AssertOrder(settings, first, second);
+        AssertOrder(new(settings), first, second);
+    }
+
+    [Fact]
+    public void ExplicitConverterPositionIsPreserved()
+    {
+        var first = new CustomEnumConverter();
+        var second = new CustomEnumConverter();
+        var settings = new SerializationSettings();
+        settings.AddExtraSettings(_ => _.Converters.Add(first));
+        settings.AddExtraSettings(_ => _.Converters.Insert(0, second));
+
+        AssertOrder(settings, second, first);
+        AssertOrder(new(settings), second, first);
+    }
+
+    [Fact]
+    public void RemovedConverterDoesNotAffectPriority()
+    {
+        var removed = new CustomEnumConverter();
+        var first = new CustomEnumConverter();
+        var second = new CustomEnumConverter();
+        var settings = new SerializationSettings();
+        settings.AddExtraSettings(_ => _.Converters.Add(removed));
+        settings.AddExtraSettings(_ => _.Converters.Add(first));
+        settings.AddExtraSettings(
+            _ =>
+            {
+                _.Converters.Remove(removed);
+                _.Converters.Add(second);
+            });
+
+        AssertOrder(settings, first, second);
+        AssertOrder(new(settings), first, second);
+    }
+
+    static void AssertOrder(SerializationSettings settings, JsonConverter first, JsonConverter second)
+    {
+        Assert.Same(first, settings.Serializer.Converters[0]);
+        Assert.Same(second, settings.Serializer.Converters[1]);
+    }
+
+    static void AssertUsesConverter(SerializationSettings settings, JsonConverter converter)
+        => Assert.Same(converter, settings.Serializer.Converters[0]);
+
+    class CustomEnumConverter :
+        WriteOnlyJsonConverter<TestEnum>
+    {
+        public override void Write(VerifyJsonWriter writer, TestEnum value) =>
+            writer.WriteValue("custom");
+    }
+
+    enum TestEnum
+    {
+        Value
+    }
+}

--- a/src/Verify/Serialization/SerializationSettings.cs
+++ b/src/Verify/Serialization/SerializationSettings.cs
@@ -37,6 +37,7 @@ partial class SerializationSettings
     static CombinationResultsConverter combinationResultsConverter = new();
 
     JsonSerializerSettings jsonSettings;
+    List<JsonConverter> builtInConverters = [];
 
     public SerializationSettings()
     {
@@ -132,6 +133,7 @@ partial class SerializationSettings
         converters.Add(stringDictionaryConverter);
         converters.Add(keyValuePairConverter);
         converters.Add(combinationResultsConverter);
+        builtInConverters = converters.ToList();
         foreach (var extraSetting in extraSettings)
         {
             ApplyExtraSetting(settings, extraSetting);
@@ -154,6 +156,8 @@ partial class SerializationSettings
 
         action(settings);
 
+        PromoteExtraConverters(settings.Converters);
+
         if (settings.DefaultValueHandling is null)
         {
             settings.DefaultValueHandling = current;
@@ -161,6 +165,41 @@ partial class SerializationSettings
         else
         {
             DefaultValueHandlingExplicit = true;
+        }
+    }
+
+    void PromoteExtraConverters(IList<JsonConverter> converters)
+    {
+        var remainingBuiltIns = builtInConverters.ToList();
+        var extras = new List<JsonConverter>();
+        var builtIns = new List<JsonConverter>();
+        foreach (var converter in converters)
+        {
+            var index = remainingBuiltIns.FindIndex(_ => ReferenceEquals(_, converter));
+            if (index < 0)
+            {
+                extras.Add(converter);
+                continue;
+            }
+
+            remainingBuiltIns.RemoveAt(index);
+            builtIns.Add(converter);
+        }
+
+        if (extras.Count == 0)
+        {
+            return;
+        }
+
+        converters.Clear();
+        foreach (var converter in extras)
+        {
+            converters.Add(converter);
+        }
+
+        foreach (var converter in builtIns)
+        {
+            converters.Add(converter);
         }
     }
 


### PR DESCRIPTION
## Summary

- Give converters added through `AddExtraSettings` priority over Verify's built-in converters.
- Preserve custom converter order when settings are changed or copied.
- Add tests for overriding, ordering, insertion, and removal.

Fixes #1834

## Validation

- 4 focused tests passed.
- `Verify.Tests` on .NET 11: 1,362 total, 0 failed.
- Release solution build passed.