### PR TITLE
Nest snapshots by updating the SDK's None items

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -945,8 +945,15 @@ Verify comes with default MSBuild includes for snapshot files (`*.received.*` an
   <PropertyGroup Condition="('$(DisableVerifyFileNesting)' != 'true')">
     <VerifyRazorFileCount>@(VerifyRazorFile->Count())</VerifyRazorFileCount>
   </PropertyGroup>
+  <!--
+  The SDK has already globbed the snapshots into None, so the metadata is applied with an Update.
+  Adding a second item for a file the SDK holds would leave it in None twice, and anything that
+  copies None into Content (eg DotNetProjectFile.Analyzers) then fails the build with NETSDK1022.
+  The Include only picks up snapshots the SDK did not, such as when default items are disabled.
+  -->
   <ItemGroup Condition="('$(DisableVerifyFileNesting)' != 'true')">
-    <None Include="**\*.received.*;**\*.verified.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'C#'">
+    <None Include="**\*.received.*;**\*.verified.*" Exclude="@(None);$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'C#' Or $(Language) == 'VB'" />
+    <None Update="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'C#'">
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
       <ParentExtension>.cs</ParentExtension>
       <!-- A Blazor component keeps its code in a .razor.cs code-behind, or in the .razor file itself -->
@@ -954,14 +961,14 @@ Verify comes with default MSBuild includes for snapshot files (`*.received.*` an
       <ParentExtension Condition="'$(VerifyRazorFileCount)' != '0' And '%(ParentExtension)' == '.cs' And !Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).cs') And Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).razor')">.razor</ParentExtension>
       <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
     </None>
-    <None Include="**\*.received.*;**\*.verified.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'VB'">
+    <None Update="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'VB'">
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
       <DependentUpon>%(ParentFile).vb</DependentUpon>
     </None>
   </ItemGroup>
 </Project>
 ```
-<sup><a href='/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props#L1-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-Verify.AfterMicrosoftNetSdk.props' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props#L1-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-Verify.AfterMicrosoftNetSdk.props' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To opt out of this feature, include the following in the project file:

--- a/src/Verify.Tests/FileNestingTests.RazorProjectWithNonePromotedToContent.verified.txt
+++ b/src/Verify.Tests/FileNestingTests.RazorProjectWithNonePromotedToContent.verified.txt
@@ -1,0 +1,5 @@
+﻿None
+  ComponentTests.Simple.verified.html: ComponentTests.razor.cs
+Content
+  ComponentTests.Simple.verified.html: ComponentTests.razor.cs
+  ComponentTests.Simple.verified.json: ComponentTests.razor.cs

--- a/src/Verify.Tests/FileNestingTests.RazorProjectWithSnapshotsAsContent.verified.txt
+++ b/src/Verify.Tests/FileNestingTests.RazorProjectWithSnapshotsAsContent.verified.txt
@@ -1,0 +1,5 @@
+﻿None
+  none
+Content
+  ComponentTests.Simple.verified.html: ComponentTests.razor.cs
+  ComponentTests.Simple.verified.json: ComponentTests.razor.cs

--- a/src/Verify.Tests/FileNestingTests.cs
+++ b/src/Verify.Tests/FileNestingTests.cs
@@ -76,6 +76,27 @@ public class FileNestingTests
                 "ComponentTests.Simple.verified.html",
                 "ComponentTests.Simple.verified.json"));
 
+    // https://github.com/VerifyTests/Verify.Bunit/issues/108#issuecomment-5523781048
+    // DotNetProjectFile.Analyzers promotes every None item to Content for its SonarQube
+    // integration, in builds outside an IDE. A snapshot is None twice, once from the SDK glob and
+    // once from Verify, so it became Content twice and the build failed with NETSDK1022.
+    [Fact]
+    public async Task RazorProjectWithNonePromotedToContent() =>
+        await Verify(
+            await Evaluate(
+                CSharp(
+                    "Microsoft.NET.Sdk.Razor",
+                    body:
+                    """
+                      <ItemGroup>
+                        <Content Include="@(None)" Exclude="@(Content)" Visible="false" />
+                      </ItemGroup>
+                    """),
+                "ComponentTests.razor",
+                "ComponentTests.razor.cs",
+                "ComponentTests.Simple.verified.html",
+                "ComponentTests.Simple.verified.json"));
+
     [Fact]
     public async Task RazorProjectWithNestingDisabled() =>
         await Verify(
@@ -196,21 +217,18 @@ public class FileNestingTests
         return builder.ToString();
     }
 
-    // Verify adds its own item for a snapshot on top of the one the SDK globbed, so the same file
-    // can appear more than once. Any disagreement between those items is a bug.
-    static string Parent(IEnumerable<(string Identity, string? Parent)> snapshot)
+    // The SDK globs a snapshot into None and Verify only updates that item, so a file listed twice
+    // means an item was added on top of the glob. That is what the SDK rejects once the None items
+    // are copied into Content, so it is reported rather than merged.
+    static string Parent(IGrouping<string, (string Identity, string? Parent)> snapshot)
     {
-        var parents = snapshot
-            .Select(_ => _.Parent)
-            .Where(_ => _ != null)
-            .Distinct()
-            .ToList();
-        if (parents.Count == 0)
+        var items = snapshot.ToList();
+        if (items.Count > 1)
         {
-            return "not nested";
+            throw new($"{snapshot.Key} is included {items.Count} times");
         }
 
-        return string.Join(" and ", parents);
+        return items[0].Parent ?? "not nested";
     }
 
     static List<IGrouping<string, (string Identity, string? Parent)>> Snapshots(JsonElement items, string type)

--- a/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props
+++ b/src/Verify/buildTransitive/Verify.AfterMicrosoftNetSdk.props
@@ -11,8 +11,15 @@
   <PropertyGroup Condition="('$(DisableVerifyFileNesting)' != 'true')">
     <VerifyRazorFileCount>@(VerifyRazorFile->Count())</VerifyRazorFileCount>
   </PropertyGroup>
+  <!--
+  The SDK has already globbed the snapshots into None, so the metadata is applied with an Update.
+  Adding a second item for a file the SDK holds would leave it in None twice, and anything that
+  copies None into Content (eg DotNetProjectFile.Analyzers) then fails the build with NETSDK1022.
+  The Include only picks up snapshots the SDK did not, such as when default items are disabled.
+  -->
   <ItemGroup Condition="('$(DisableVerifyFileNesting)' != 'true')">
-    <None Include="**\*.received.*;**\*.verified.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'C#'">
+    <None Include="**\*.received.*;**\*.verified.*" Exclude="@(None);$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'C#' Or $(Language) == 'VB'" />
+    <None Update="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'C#'">
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
       <ParentExtension>.cs</ParentExtension>
       <!-- A Blazor component keeps its code in a .razor.cs code-behind, or in the .razor file itself -->
@@ -20,7 +27,7 @@
       <ParentExtension Condition="'$(VerifyRazorFileCount)' != '0' And '%(ParentExtension)' == '.cs' And !Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).cs') And Exists('$(MSBuildProjectDirectory)\%(RelativeDir)%(ParentFile).razor')">.razor</ParentExtension>
       <DependentUpon>%(ParentFile)%(ParentExtension)</DependentUpon>
     </None>
-    <None Include="**\*.received.*;**\*.verified.*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" Condition="$(Language) == 'VB'">
+    <None Update="**\*.received.*;**\*.verified.*" Condition="$(Language) == 'VB'">
       <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0].Split('(')[0])</ParentFile>
       <DependentUpon>%(ParentFile).vb</DependentUpon>
     </None>


### PR DESCRIPTION
Verify.AfterMicrosoftNetSdk.props added a None item per snapshot to carry DependentUpon, on top of the item the SDK's **/* glob had already produced. So every snapshot sat in None twice. DotNetProjectFile.Analyzers copies @(None) into Content for its SonarQube integration in non-IDE builds, which turned those into duplicate Content items and failed the build with NETSDK1022.

The metadata is now applied with None Update to the SDK's item. The Include remains only for snapshots the SDK did not glob, such as when default items are disabled.

FileNestingTests run the SDK's CheckForDuplicateItems target alongside the item evaluation, fail on any file listed twice, and cover a project that promotes None to Content as well as one that declares html snapshots as Content itself.

https://github.com/VerifyTests/Verify.Bunit/issues/108