### PR TITLE
Bump DiffEngine to 20.3.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Argon" Version="0.36.0" />
     <PackageVersion Include="Argon.FSharp" Version="0.36.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="DiffEngine" Version="20.2.2" />
+    <PackageVersion Include="DiffEngine" Version="20.3.0" />
     <PackageVersion Include="Expecto" Version="11.1.0" />
     <PackageVersion Include="Fixie" Version="4.2.0" />
     <PackageVersion Include="Fixie.TestAdapter" Version="4.2.0" />


### PR DESCRIPTION
Updates the centrally managed DiffEngine package version from 20.2.2 to 20.3.0.